### PR TITLE
fix(e2e): Fix failing E2E tests for user info and organization validation

### DIFF
--- a/__tests__/e2e/flows/auth.spec.ts
+++ b/__tests__/e2e/flows/auth.spec.ts
@@ -166,18 +166,15 @@ test.describe('Authentication Flow', () => {
 
       await expect(page).toHaveURL(/\/(dashboard|organizations|settings)/, { timeout: 15000 });
 
-      // User info should be visible in header or menu
-      const userInfo = page.getByText(new RegExp(TEST_USER.email + '|' + TEST_USER.name, 'i'));
-      const isVisible = await userInfo.isVisible().catch(() => false);
+      // User info should be visible - check for welcome message or user button
+      const welcomeMessage = page.getByText(/welcome.*back/i);
+      const userButton = page.getByRole('button', { name: new RegExp(TEST_USER.name, 'i') });
 
-      // User info might be in dropdown menu
-      if (!isVisible) {
-        const userMenu = page.locator('[data-testid="user-menu"]').or(page.getByRole('button', { name: /account|user|profile/i }));
-        if (await userMenu.isVisible()) {
-          await userMenu.click();
-          await expect(page.getByText(new RegExp(TEST_USER.email + '|' + TEST_USER.name, 'i'))).toBeVisible();
-        }
-      }
+      // Either welcome message or user button with name should be visible
+      const hasWelcome = await welcomeMessage.isVisible().catch(() => false);
+      const hasUserButton = await userButton.isVisible().catch(() => false);
+
+      expect(hasWelcome || hasUserButton).toBeTruthy();
     });
 
     test('should logout successfully', async ({ page }) => {

--- a/__tests__/e2e/flows/organizations.spec.ts
+++ b/__tests__/e2e/flows/organizations.spec.ts
@@ -57,17 +57,30 @@ test.describe('Organization Management', () => {
       await login(page);
       await page.goto('/organizations');
 
-      const createButton = page.getByRole('button', { name: /create|new|add/i });
-      if (await createButton.isVisible()) {
-        await createButton.click();
+      // Click "New Organization" or "Create Organization" button to open modal
+      const newOrgButton = page.getByRole('button', { name: /new organization/i });
+      const createOrgButton = page.getByRole('button', { name: /create organization/i });
 
-        // Try to submit with empty name
-        const submitButton = page.getByRole('button', { name: /create|submit|save/i });
-        if (await submitButton.isVisible()) {
-          await submitButton.click();
-          // Validation error should appear
-          await page.waitForTimeout(500);
-        }
+      if (await newOrgButton.isVisible()) {
+        await newOrgButton.click();
+      } else if (await createOrgButton.isVisible()) {
+        await createOrgButton.click();
+      }
+
+      // Wait for modal to appear
+      await page.waitForTimeout(500);
+
+      // The submit button should be disabled when name is empty (this IS the validation)
+      const submitButton = page.locator('button:has-text("Create Organization")').last();
+      await expect(submitButton).toBeDisabled();
+
+      // Fill in organization name
+      const nameField = page.getByPlaceholder('My Organization');
+      if (await nameField.isVisible()) {
+        await nameField.fill('Test Organization');
+
+        // Button should now be enabled
+        await expect(submitButton).toBeEnabled();
       }
     });
 


### PR DESCRIPTION
## Summary
- `should display user info when authenticated`: Simplified test logic to check for welcome message or user button
- `should validate organization name`: Fixed to verify button disabled state when form is empty

## Test Results
```
27 passed (17.0s)
```

## Test plan
- [x] Run auth E2E tests
- [x] Run organizations E2E tests
- [x] Verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)