### PR TITLE
feat: すべてのUIを日本語対応

### DIFF
--- a/src/app/(dashboard)/projects/page.tsx
+++ b/src/app/(dashboard)/projects/page.tsx
@@ -60,9 +60,9 @@ export default async function ProjectsPage() {
               </svg>
             </Link>
             <div>
-              <h1 className="text-2xl font-bold text-gray-900">Projects</h1>
+              <h1 className="text-2xl font-bold text-gray-900">プロジェクト</h1>
               <p className="text-sm text-gray-600">
-                Manage all your construction photo projects
+                工事写真プロジェクトの管理
               </p>
             </div>
           </div>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -43,9 +43,9 @@ export default function NotFound() {
   };
 
   const quickLinks = [
-    { href: '/dashboard', label: 'Dashboard', icon: Home },
-    { href: '/organizations', label: 'Organizations', icon: Building2 },
-    { href: '/settings', label: 'Settings', icon: Settings },
+    { href: '/dashboard', label: 'ダッシュボード', icon: Home },
+    { href: '/organizations', label: '組織', icon: Building2 },
+    { href: '/settings', label: '設定', icon: Settings },
   ];
 
   return (
@@ -78,13 +78,13 @@ export default function NotFound() {
 
         {/* Title */}
         <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-3">
-          Page Not Found
+          ページが見つかりません
         </h1>
 
         {/* Description */}
         <p className="text-gray-500 dark:text-gray-400 mb-8 max-w-md mx-auto">
-          The page you&apos;re looking for doesn&apos;t exist or has been moved.
-          Try searching or use the links below.
+          お探しのページは存在しないか、移動された可能性があります。
+          検索するか、下のリンクをご利用ください。
         </p>
 
         {/* Search box */}
@@ -95,7 +95,7 @@ export default function NotFound() {
               type="text"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="Search for photos, projects..."
+              placeholder="写真やプロジェクトを検索..."
               className="
                 w-full pl-12 pr-4 py-3
                 bg-white dark:bg-gray-800
@@ -120,7 +120,7 @@ export default function NotFound() {
                 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
               "
             >
-              Search
+              検索
             </button>
           </div>
         </form>
@@ -141,7 +141,7 @@ export default function NotFound() {
             "
           >
             <Home className="w-5 h-5" />
-            Go to Home
+            ホームへ戻る
           </Link>
 
           <button
@@ -161,7 +161,7 @@ export default function NotFound() {
             "
           >
             <ArrowLeft className="w-5 h-5" />
-            Go Back
+            前のページへ
           </button>
         </div>
 
@@ -193,20 +193,20 @@ export default function NotFound() {
         {/* Additional helpful links */}
         <div className="pt-8 border-t border-gray-200 dark:border-gray-700">
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-            Or try these pages:
+            または以下のページをお試しください:
           </p>
           <div className="flex flex-wrap justify-center gap-x-6 gap-y-2 text-sm">
             <Link
               href="/login"
               className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 hover:underline"
             >
-              Login
+              ログイン
             </Link>
             <Link
               href="/register"
               className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 hover:underline"
             >
-              Register
+              新規登録
             </Link>
           </div>
         </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -74,7 +74,7 @@ export function Header({ onMenuClick }: HeaderProps) {
                 {userInitials}
               </div>
               <span className="hidden md:block text-sm font-medium text-gray-700 dark:text-gray-300">
-                {session?.user?.name || 'User'}
+                {session?.user?.name || 'ユーザー'}
               </span>
               <ChevronDown className="hidden md:block h-4 w-4 text-gray-500 dark:text-gray-400" />
             </button>
@@ -83,7 +83,7 @@ export function Header({ onMenuClick }: HeaderProps) {
               <div className="absolute right-0 mt-2 w-56 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50">
                 <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
                   <p className="text-sm font-medium text-gray-900 dark:text-white">
-                    {session?.user?.name || 'User'}
+                    {session?.user?.name || 'ユーザー'}
                   </p>
                   <p className="text-sm text-gray-500 dark:text-gray-400 truncate">
                     {session?.user?.email || ''}
@@ -98,7 +98,7 @@ export function Header({ onMenuClick }: HeaderProps) {
                     className="w-full flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                   >
                     <User className="h-4 w-4" />
-                    Profile
+                    プロフィール
                   </button>
                 </div>
 
@@ -108,7 +108,7 @@ export function Header({ onMenuClick }: HeaderProps) {
                     className="w-full flex items-center gap-2 px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                   >
                     <LogOut className="h-4 w-4" />
-                    Sign out
+                    ログアウト
                   </button>
                 </div>
               </div>

--- a/src/components/projects/DeleteProjectDialog.tsx
+++ b/src/components/projects/DeleteProjectDialog.tsx
@@ -32,7 +32,7 @@ export function DeleteProjectDialog({
 
   const handleDelete = async () => {
     if (hasAssociatedData && confirmText !== project.name) {
-      setError('Please type the project name to confirm deletion');
+      setError('削除を確認するためにプロジェクト名を入力してください');
       return;
     }
 
@@ -47,12 +47,12 @@ export function DeleteProjectDialog({
       const result = await response.json();
 
       if (!result.success) {
-        throw new Error(result.error || 'Failed to delete project');
+        throw new Error(result.error || 'プロジェクトの削除に失敗しました');
       }
 
       onConfirm();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete project');
+      setError(err instanceof Error ? err.message : 'プロジェクトの削除に失敗しました');
       setDeleting(false);
     }
   };
@@ -74,7 +74,7 @@ export function DeleteProjectDialog({
               <div className="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
                 <AlertTriangle className="w-5 h-5 text-red-600" />
               </div>
-              <h2 className="text-lg font-semibold text-gray-900">Delete Project</h2>
+              <h2 className="text-lg font-semibold text-gray-900">プロジェクトを削除</h2>
             </div>
             <button
               onClick={onCancel}
@@ -87,29 +87,28 @@ export function DeleteProjectDialog({
           {/* Content */}
           <div className="px-6 py-4 space-y-4">
             <p className="text-gray-700">
-              Are you sure you want to delete{' '}
-              <span className="font-semibold">{project.name}</span>?
+              <span className="font-semibold">{project.name}</span> を削除してもよろしいですか？
             </p>
 
             {/* Warning about associated data */}
             {hasAssociatedData && (
               <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
                 <p className="text-sm text-yellow-800 font-medium mb-2">
-                  This project contains:
+                  このプロジェクトには以下が含まれています:
                 </p>
                 <ul className="text-sm text-yellow-700 space-y-1">
                   {project._count.photos > 0 && (
-                    <li>- {project._count.photos} photo(s)</li>
+                    <li>- {project._count.photos} 枚の写真</li>
                   )}
                   {project._count.albums > 0 && (
-                    <li>- {project._count.albums} album(s)</li>
+                    <li>- {project._count.albums} 件のアルバム</li>
                   )}
                   {project._count.members > 0 && (
-                    <li>- {project._count.members} member(s)</li>
+                    <li>- {project._count.members} 人のメンバー</li>
                   )}
                 </ul>
                 <p className="text-sm text-yellow-800 mt-2">
-                  All associated data will be permanently deleted.
+                  関連するすべてのデータが完全に削除されます。
                 </p>
               </div>
             )}
@@ -118,13 +117,13 @@ export function DeleteProjectDialog({
             {hasAssociatedData && (
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Type <span className="font-semibold">{project.name}</span> to confirm:
+                  削除を確認するには <span className="font-semibold">{project.name}</span> と入力してください:
                 </label>
                 <input
                   type="text"
                   value={confirmText}
                   onChange={(e) => setConfirmText(e.target.value)}
-                  placeholder="Project name"
+                  placeholder="プロジェクト名"
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500"
                 />
               </div>
@@ -146,7 +145,7 @@ export function DeleteProjectDialog({
               className="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-100"
               disabled={deleting}
             >
-              Cancel
+              キャンセル
             </button>
             <button
               type="button"
@@ -155,7 +154,7 @@ export function DeleteProjectDialog({
               disabled={deleting || (hasAssociatedData && confirmText !== project.name)}
             >
               {deleting && <Loader2 className="w-4 h-4 animate-spin" />}
-              {deleting ? 'Deleting...' : 'Delete Project'}
+              {deleting ? '削除中...' : '削除'}
             </button>
           </div>
         </div>

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -90,7 +90,7 @@ export function ProjectCard({ project, onEdit, onDelete }: ProjectCardProps) {
                   onClick={() => setShowMenu(false)}
                 >
                   <Eye className="w-4 h-4" />
-                  View Project
+                  表示
                 </Link>
                 <button
                   onClick={() => {
@@ -100,7 +100,7 @@ export function ProjectCard({ project, onEdit, onDelete }: ProjectCardProps) {
                   className="flex items-center gap-2 w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
                 >
                   <Edit className="w-4 h-4" />
-                  Edit
+                  編集
                 </button>
                 <button
                   onClick={() => {
@@ -110,7 +110,7 @@ export function ProjectCard({ project, onEdit, onDelete }: ProjectCardProps) {
                   className="flex items-center gap-2 w-full px-4 py-2 text-sm text-red-600 hover:bg-red-50"
                 >
                   <Trash2 className="w-4 h-4" />
-                  Delete
+                  削除
                 </button>
               </div>
             )}
@@ -142,7 +142,7 @@ export function ProjectCard({ project, onEdit, onDelete }: ProjectCardProps) {
                 {project._count.photos}
               </span>
             </div>
-            <span className="text-xs text-gray-500">Photos</span>
+            <span className="text-xs text-gray-500">写真</span>
           </div>
           <div className="text-center">
             <div className="flex items-center justify-center gap-1 text-gray-500">
@@ -151,7 +151,7 @@ export function ProjectCard({ project, onEdit, onDelete }: ProjectCardProps) {
                 {project._count.albums}
               </span>
             </div>
-            <span className="text-xs text-gray-500">Albums</span>
+            <span className="text-xs text-gray-500">アルバム</span>
           </div>
           <div className="text-center">
             <div className="flex items-center justify-center gap-1 text-gray-500">
@@ -160,7 +160,7 @@ export function ProjectCard({ project, onEdit, onDelete }: ProjectCardProps) {
                 {project._count.members}
               </span>
             </div>
-            <span className="text-xs text-gray-500">Members</span>
+            <span className="text-xs text-gray-500">メンバー</span>
           </div>
         </div>
       </div>
@@ -169,17 +169,17 @@ export function ProjectCard({ project, onEdit, onDelete }: ProjectCardProps) {
       <div className="px-4 py-3 bg-gray-50 rounded-b-lg border-t border-gray-100">
         <div className="flex justify-between text-xs text-gray-500">
           <div>
-            <span className="font-medium">Start:</span> {formatDate(project.startDate)}
+            <span className="font-medium">開始:</span> {formatDate(project.startDate)}
           </div>
           <div>
-            <span className="font-medium">End:</span> {formatDate(project.endDate)}
+            <span className="font-medium">終了:</span> {formatDate(project.endDate)}
           </div>
         </div>
         {(project.clientName || project.contractorName) && (
           <div className="mt-2 text-xs text-gray-500 truncate">
-            {project.clientName && <span>Client: {project.clientName}</span>}
+            {project.clientName && <span>発注者: {project.clientName}</span>}
             {project.clientName && project.contractorName && <span> | </span>}
-            {project.contractorName && <span>Contractor: {project.contractorName}</span>}
+            {project.contractorName && <span>施工者: {project.contractorName}</span>}
           </div>
         )}
       </div>

--- a/src/components/projects/ProjectForm.tsx
+++ b/src/components/projects/ProjectForm.tsx
@@ -65,7 +65,7 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
     setError(null);
 
     if (!name.trim()) {
-      setError('Project name is required');
+      setError('プロジェクト名は必須です');
       return;
     }
 
@@ -96,12 +96,12 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
       const result = await response.json();
 
       if (!result.success) {
-        throw new Error(result.error || 'Failed to save project');
+        throw new Error(result.error || 'プロジェクトの保存に失敗しました');
       }
 
       onSave();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save project');
+      setError(err instanceof Error ? err.message : 'プロジェクトの保存に失敗しました');
     } finally {
       setSaving(false);
     }
@@ -109,10 +109,10 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
 
   // Status options
   const statusOptions: { value: ProjectStatus; label: string }[] = [
-    { value: 'ACTIVE', label: 'Active' },
-    { value: 'COMPLETED', label: 'Completed' },
-    { value: 'ARCHIVED', label: 'Archived' },
-    { value: 'SUSPENDED', label: 'Suspended' },
+    { value: 'ACTIVE', label: '進行中' },
+    { value: 'COMPLETED', label: '完了' },
+    { value: 'ARCHIVED', label: 'アーカイブ' },
+    { value: 'SUSPENDED', label: '一時停止' },
   ];
 
   return (
@@ -129,7 +129,7 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
           {/* Header */}
           <div className="flex items-center justify-between px-6 py-4 border-b">
             <h2 className="text-lg font-semibold text-gray-900">
-              {isEditing ? 'Edit Project' : 'Create New Project'}
+              {isEditing ? 'プロジェクトを編集' : '新規プロジェクト作成'}
             </h2>
             <button
               onClick={onCancel}
@@ -151,20 +151,20 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
             {/* Basic Info Section */}
             <div className="space-y-4">
               <h3 className="text-sm font-medium text-gray-700 uppercase tracking-wide">
-                Basic Information
+                基本情報
               </h3>
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="md:col-span-2">
                   <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-1">
-                    Project Name <span className="text-red-500">*</span>
+                    プロジェクト名 <span className="text-red-500">*</span>
                   </label>
                   <input
                     type="text"
                     id="name"
                     value={name}
                     onChange={(e) => setName(e.target.value)}
-                    placeholder="Enter project name"
+                    placeholder="プロジェクト名を入力"
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     required
                     autoFocus
@@ -173,21 +173,21 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
 
                 <div>
                   <label htmlFor="code" className="block text-sm font-medium text-gray-700 mb-1">
-                    Project Code
+                    プロジェクトコード
                   </label>
                   <input
                     type="text"
                     id="code"
                     value={code}
                     onChange={(e) => setCode(e.target.value)}
-                    placeholder="e.g., PRJ-001"
+                    placeholder="例: PRJ-001"
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                   />
                 </div>
 
                 <div>
                   <label htmlFor="status" className="block text-sm font-medium text-gray-700 mb-1">
-                    Status
+                    ステータス
                   </label>
                   <select
                     id="status"
@@ -205,13 +205,13 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
 
                 <div className="md:col-span-2">
                   <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-1">
-                    Description
+                    説明
                   </label>
                   <textarea
                     id="description"
                     value={description}
                     onChange={(e) => setDescription(e.target.value)}
-                    placeholder="Enter project description"
+                    placeholder="プロジェクトの説明を入力"
                     rows={3}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                   />
@@ -222,48 +222,48 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
             {/* Client Info Section */}
             <div className="space-y-4">
               <h3 className="text-sm font-medium text-gray-700 uppercase tracking-wide">
-                Client Information
+                発注者・施工者情報
               </h3>
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
                   <label htmlFor="clientName" className="block text-sm font-medium text-gray-700 mb-1">
-                    Client Name
+                    発注者名
                   </label>
                   <input
                     type="text"
                     id="clientName"
                     value={clientName}
                     onChange={(e) => setClientName(e.target.value)}
-                    placeholder="Enter client name"
+                    placeholder="発注者名を入力"
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                   />
                 </div>
 
                 <div>
                   <label htmlFor="contractorName" className="block text-sm font-medium text-gray-700 mb-1">
-                    Contractor Name
+                    施工者名
                   </label>
                   <input
                     type="text"
                     id="contractorName"
                     value={contractorName}
                     onChange={(e) => setContractorName(e.target.value)}
-                    placeholder="Enter contractor name"
+                    placeholder="施工者名を入力"
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                   />
                 </div>
 
                 <div className="md:col-span-2">
                   <label htmlFor="location" className="block text-sm font-medium text-gray-700 mb-1">
-                    Location
+                    工事場所
                   </label>
                   <input
                     type="text"
                     id="location"
                     value={location}
                     onChange={(e) => setLocation(e.target.value)}
-                    placeholder="Enter project location"
+                    placeholder="工事場所を入力"
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                   />
                 </div>
@@ -273,13 +273,13 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
             {/* Schedule Section */}
             <div className="space-y-4">
               <h3 className="text-sm font-medium text-gray-700 uppercase tracking-wide">
-                Schedule
+                工期
               </h3>
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
                   <label htmlFor="startDate" className="block text-sm font-medium text-gray-700 mb-1">
-                    Start Date
+                    開始日
                   </label>
                   <input
                     type="date"
@@ -292,7 +292,7 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
 
                 <div>
                   <label htmlFor="endDate" className="block text-sm font-medium text-gray-700 mb-1">
-                    End Date
+                    終了日
                   </label>
                   <input
                     type="date"
@@ -313,7 +313,7 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
                 className="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50"
                 disabled={saving}
               >
-                Cancel
+                キャンセル
               </button>
               <button
                 type="submit"
@@ -321,7 +321,7 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
                 disabled={saving || !name.trim()}
               >
                 {saving && <Loader2 className="w-4 h-4 animate-spin" />}
-                {saving ? 'Saving...' : isEditing ? 'Update Project' : 'Create Project'}
+                {saving ? '保存中...' : isEditing ? '更新' : '作成'}
               </button>
             </div>
           </form>


### PR DESCRIPTION
## Summary
- Header: プロフィール、ログアウトメニュー項目を日本語化
- プロジェクト一覧ページ: ページタイトル、説明文を日本語化
- ProjectCard: メニュー項目（表示/編集/削除）、統計ラベル（写真/アルバム/メンバー）、日付ラベル（開始/終了）、発注者/施工者を日本語化
- ProjectForm: フォームラベル、プレースホルダー、ボタン、エラーメッセージを日本語化
- DeleteProjectDialog: 確認メッセージ、警告文、ボタンを日本語化
- 404ページ: 全文を日本語化（タイトル、説明、ボタン、リンク）

## Test plan
- [ ] ログイン後のHeaderのユーザーメニューが日本語表示されること
- [ ] プロジェクト一覧ページのタイトル・説明が日本語表示されること
- [ ] プロジェクトカードの各項目が日本語表示されること
- [ ] プロジェクト作成/編集フォームが日本語表示されること
- [ ] プロジェクト削除ダイアログが日本語表示されること
- [ ] 404ページが日本語表示されること
- [ ] ビルドが正常に完了すること ✅

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)