### PR TITLE
feat: サイドバーナビに対応するページを実装

### DIFF
--- a/src/app/(dashboard)/albums/page.tsx
+++ b/src/app/(dashboard)/albums/page.tsx
@@ -1,0 +1,107 @@
+import { auth } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import { prisma } from '@/lib/prisma';
+import Link from 'next/link';
+import { BookOpen, FolderOpen, Image, Calendar, ArrowRight } from 'lucide-react';
+
+export default async function AlbumsPage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  // Get all albums with project info
+  const albums = await prisma.album.findMany({
+    orderBy: { updatedAt: 'desc' },
+    include: {
+      project: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+      _count: {
+        select: { photos: true },
+      },
+    },
+  });
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">アルバム</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            全プロジェクトのアルバムを管理 ({albums.length}件)
+          </p>
+        </div>
+      </div>
+
+      {/* Albums Grid */}
+      {albums.length === 0 ? (
+        <div className="text-center py-12 bg-gray-50 dark:bg-gray-800 rounded-lg">
+          <BookOpen className="w-12 h-12 mx-auto text-gray-400 mb-4" />
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+            アルバムがありません
+          </h3>
+          <p className="text-gray-500 dark:text-gray-400 mb-4">
+            プロジェクト内でアルバムを作成してください
+          </p>
+          <Link
+            href="/projects"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+          >
+            <FolderOpen className="w-4 h-4" />
+            プロジェクト一覧へ
+          </Link>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {albums.map((album) => (
+            <Link
+              key={album.id}
+              href={`/projects/${album.project.id}/albums/${album.id}`}
+              className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 hover:shadow-md transition-shadow p-4 group"
+            >
+              <div className="flex items-start justify-between">
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 bg-purple-100 dark:bg-purple-900/50 rounded-lg flex items-center justify-center">
+                    <BookOpen className="w-5 h-5 text-purple-600 dark:text-purple-400" />
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-gray-900 dark:text-white">
+                      {album.name}
+                    </h3>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {album.project.name}
+                    </p>
+                  </div>
+                </div>
+                <ArrowRight className="w-4 h-4 text-gray-400 group-hover:text-blue-600 transition-colors" />
+              </div>
+
+              {album.description && (
+                <p className="mt-3 text-sm text-gray-600 dark:text-gray-400 line-clamp-2">
+                  {album.description}
+                </p>
+              )}
+
+              <div className="flex items-center gap-4 mt-4 text-sm text-gray-500 dark:text-gray-400">
+                <span className="flex items-center gap-1">
+                  <Image className="w-4 h-4" />
+                  {album._count.photos}枚
+                </span>
+                <span className="flex items-center gap-1">
+                  <Calendar className="w-4 h-4" />
+                  {new Date(album.updatedAt).toLocaleDateString('ja-JP')}
+                </span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/blackboard/page.tsx
+++ b/src/app/(dashboard)/blackboard/page.tsx
@@ -1,0 +1,128 @@
+import { auth } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import { prisma } from '@/lib/prisma';
+import Link from 'next/link';
+import { Clipboard, FolderOpen, FileText, ArrowRight } from 'lucide-react';
+
+export default async function BlackboardPage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  // Get all projects with blackboard counts
+  const projects = await prisma.project.findMany({
+    orderBy: { updatedAt: 'desc' },
+    include: {
+      _count: {
+        select: { blackboards: true },
+      },
+    },
+  });
+
+  // Get blackboard templates
+  const templates = await prisma.blackboardTemplate.findMany({
+    orderBy: { isDefault: 'desc' },
+    take: 5,
+  });
+
+  const totalBlackboards = projects.reduce((sum, p) => sum + p._count.blackboards, 0);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">電子黒板</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            工事写真用の電子黒板を管理 ({totalBlackboards}件)
+          </p>
+        </div>
+      </div>
+
+      {/* Templates Section */}
+      {templates.length > 0 && (
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+            黒板テンプレート
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+            {templates.map((template) => (
+              <div
+                key={template.id}
+                className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg"
+              >
+                <div className="w-8 h-8 bg-green-100 dark:bg-green-900/50 rounded flex items-center justify-center">
+                  <FileText className="w-4 h-4 text-green-600 dark:text-green-400" />
+                </div>
+                <div>
+                  <p className="font-medium text-gray-900 dark:text-white text-sm">
+                    {template.name}
+                  </p>
+                  {template.isDefault && (
+                    <span className="text-xs text-green-600 dark:text-green-400">
+                      デフォルト
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Projects with Blackboards */}
+      {projects.length === 0 ? (
+        <div className="text-center py-12 bg-gray-50 dark:bg-gray-800 rounded-lg">
+          <Clipboard className="w-12 h-12 mx-auto text-gray-400 mb-4" />
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+            プロジェクトがありません
+          </h3>
+          <p className="text-gray-500 dark:text-gray-400 mb-4">
+            プロジェクトを作成して電子黒板を使用してください
+          </p>
+          <Link
+            href="/projects"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+          >
+            <FolderOpen className="w-4 h-4" />
+            プロジェクト一覧へ
+          </Link>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            プロジェクト別黒板
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {projects.map((project) => (
+              <Link
+                key={project.id}
+                href={`/projects/${project.id}/blackboard`}
+                className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4 hover:shadow-md transition-shadow group"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 bg-teal-100 dark:bg-teal-900/50 rounded-lg flex items-center justify-center">
+                      <Clipboard className="w-5 h-5 text-teal-600 dark:text-teal-400" />
+                    </div>
+                    <div>
+                      <h3 className="font-semibold text-gray-900 dark:text-white">
+                        {project.name}
+                      </h3>
+                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                        {project._count.blackboards}件の黒板
+                      </p>
+                    </div>
+                  </div>
+                  <ArrowRight className="w-5 h-5 text-gray-400 group-hover:text-blue-600 transition-colors" />
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/categories/page.tsx
+++ b/src/app/(dashboard)/categories/page.tsx
@@ -1,0 +1,131 @@
+import { auth } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import { prisma } from '@/lib/prisma';
+import Link from 'next/link';
+import { Tags, FolderOpen, ChevronRight, ArrowRight } from 'lucide-react';
+
+export default async function CategoriesPage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  // Get all projects with their category counts
+  const projects = await prisma.project.findMany({
+    orderBy: { updatedAt: 'desc' },
+    include: {
+      _count: {
+        select: { categories: true },
+      },
+      categories: {
+        where: { parentId: null },
+        take: 5,
+        orderBy: { sortOrder: 'asc' },
+        select: {
+          id: true,
+          name: true,
+          code: true,
+        },
+      },
+    },
+  });
+
+  const totalCategories = projects.reduce((sum, p) => sum + p._count.categories, 0);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">工種分類</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            全プロジェクトの工種分類を管理 ({totalCategories}件)
+          </p>
+        </div>
+      </div>
+
+      {/* Info Banner */}
+      <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+        <p className="text-sm text-blue-800 dark:text-blue-200">
+          工種分類はプロジェクトごとに管理されます。各プロジェクトで国交省の電子納品基準に準拠した標準分類をインポートできます。
+        </p>
+      </div>
+
+      {/* Projects with Categories */}
+      {projects.length === 0 ? (
+        <div className="text-center py-12 bg-gray-50 dark:bg-gray-800 rounded-lg">
+          <Tags className="w-12 h-12 mx-auto text-gray-400 mb-4" />
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+            プロジェクトがありません
+          </h3>
+          <p className="text-gray-500 dark:text-gray-400 mb-4">
+            プロジェクトを作成して工種分類を設定してください
+          </p>
+          <Link
+            href="/projects"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+          >
+            <FolderOpen className="w-4 h-4" />
+            プロジェクト一覧へ
+          </Link>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {projects.map((project) => (
+            <div
+              key={project.id}
+              className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700"
+            >
+              <Link
+                href={`/projects/${project.id}/categories`}
+                className="flex items-center justify-between p-4 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors rounded-t-lg group"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 bg-amber-100 dark:bg-amber-900/50 rounded-lg flex items-center justify-center">
+                    <Tags className="w-5 h-5 text-amber-600 dark:text-amber-400" />
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-gray-900 dark:text-white">
+                      {project.name}
+                    </h3>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {project._count.categories}件の分類
+                    </p>
+                  </div>
+                </div>
+                <ArrowRight className="w-5 h-5 text-gray-400 group-hover:text-blue-600 transition-colors" />
+              </Link>
+
+              {/* Category Preview */}
+              {project.categories.length > 0 && (
+                <div className="px-4 pb-4 border-t border-gray-100 dark:border-gray-700 pt-3">
+                  <div className="flex flex-wrap gap-2">
+                    {project.categories.map((category) => (
+                      <span
+                        key={category.id}
+                        className="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-sm text-gray-700 dark:text-gray-300"
+                      >
+                        {category.code && (
+                          <span className="text-gray-400 font-mono text-xs">
+                            {category.code}
+                          </span>
+                        )}
+                        {category.name}
+                      </span>
+                    ))}
+                    {project._count.categories > 5 && (
+                      <span className="inline-flex items-center px-2 py-1 text-sm text-gray-500 dark:text-gray-400">
+                        +{project._count.categories - 5}件
+                      </span>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/export/page.tsx
+++ b/src/app/(dashboard)/export/page.tsx
@@ -1,0 +1,168 @@
+import { auth } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import { prisma } from '@/lib/prisma';
+import Link from 'next/link';
+import { Download, FolderOpen, FileArchive, FileSpreadsheet, Image, ArrowRight, CheckCircle } from 'lucide-react';
+
+export default async function ExportPage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  // Get all projects with photo counts
+  const projects = await prisma.project.findMany({
+    orderBy: { updatedAt: 'desc' },
+    include: {
+      _count: {
+        select: {
+          photos: true,
+          albums: true,
+        },
+      },
+    },
+  });
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">エクスポート</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            写真データの出力・電子納品
+          </p>
+        </div>
+      </div>
+
+      {/* Export Types */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+          <div className="flex items-center gap-4 mb-4">
+            <div className="w-12 h-12 bg-blue-100 dark:bg-blue-900/50 rounded-lg flex items-center justify-center">
+              <FileArchive className="w-6 h-6 text-blue-600 dark:text-blue-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                電子納品出力
+              </h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                国交省基準準拠のXML形式
+              </p>
+            </div>
+          </div>
+          <ul className="space-y-2 text-sm text-gray-600 dark:text-gray-400 mb-4">
+            <li className="flex items-center gap-2">
+              <CheckCircle className="w-4 h-4 text-green-500" />
+              PHOTO.XML 自動生成
+            </li>
+            <li className="flex items-center gap-2">
+              <CheckCircle className="w-4 h-4 text-green-500" />
+              INDEX_C.XML 対応
+            </li>
+            <li className="flex items-center gap-2">
+              <CheckCircle className="w-4 h-4 text-green-500" />
+              フォルダ構成自動整理
+            </li>
+          </ul>
+        </div>
+
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+          <div className="flex items-center gap-4 mb-4">
+            <div className="w-12 h-12 bg-green-100 dark:bg-green-900/50 rounded-lg flex items-center justify-center">
+              <FileSpreadsheet className="w-6 h-6 text-green-600 dark:text-green-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                アルバム出力
+              </h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                ZIP形式でダウンロード
+              </p>
+            </div>
+          </div>
+          <ul className="space-y-2 text-sm text-gray-600 dark:text-gray-400 mb-4">
+            <li className="flex items-center gap-2">
+              <CheckCircle className="w-4 h-4 text-green-500" />
+              写真ファイル一括出力
+            </li>
+            <li className="flex items-center gap-2">
+              <CheckCircle className="w-4 h-4 text-green-500" />
+              メタデータ付与
+            </li>
+            <li className="flex items-center gap-2">
+              <CheckCircle className="w-4 h-4 text-green-500" />
+              黒板合成写真対応
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      {/* Projects */}
+      <div className="space-y-4">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          プロジェクトを選択してエクスポート
+        </h2>
+
+        {projects.length === 0 ? (
+          <div className="text-center py-12 bg-gray-50 dark:bg-gray-800 rounded-lg">
+            <Download className="w-12 h-12 mx-auto text-gray-400 mb-4" />
+            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+              エクスポートできるプロジェクトがありません
+            </h3>
+            <p className="text-gray-500 dark:text-gray-400 mb-4">
+              プロジェクトを作成して写真をアップロードしてください
+            </p>
+            <Link
+              href="/projects"
+              className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+            >
+              <FolderOpen className="w-4 h-4" />
+              プロジェクト一覧へ
+            </Link>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {projects.map((project) => (
+              <div
+                key={project.id}
+                className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4"
+              >
+                <div className="flex items-center gap-3 mb-4">
+                  <div className="w-10 h-10 bg-indigo-100 dark:bg-indigo-900/50 rounded-lg flex items-center justify-center">
+                    <FolderOpen className="w-5 h-5 text-indigo-600 dark:text-indigo-400" />
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-gray-900 dark:text-white">
+                      {project.name}
+                    </h3>
+                    <div className="flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+                      <span className="flex items-center gap-1">
+                        <Image className="w-3 h-3" />
+                        {project._count.photos}枚
+                      </span>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Link
+                    href={`/projects/${project.id}/albums`}
+                    className="flex items-center justify-between w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 rounded-lg text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors"
+                  >
+                    <span className="flex items-center gap-2">
+                      <FileSpreadsheet className="w-4 h-4" />
+                      アルバムからエクスポート
+                    </span>
+                    <ArrowRight className="w-4 h-4" />
+                  </Link>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/photos/page.tsx
+++ b/src/app/(dashboard)/photos/page.tsx
@@ -1,0 +1,136 @@
+import { auth } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import { prisma } from '@/lib/prisma';
+import Link from 'next/link';
+import { Image, FolderOpen, Calendar, ArrowRight } from 'lucide-react';
+
+export default async function PhotosPage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  // Get all photos grouped by project
+  const projects = await prisma.project.findMany({
+    orderBy: { updatedAt: 'desc' },
+    include: {
+      _count: {
+        select: { photos: true },
+      },
+      photos: {
+        take: 4,
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          thumbnailPath: true,
+          title: true,
+        },
+      },
+    },
+  });
+
+  const totalPhotos = projects.reduce((sum, p) => sum + p._count.photos, 0);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">写真</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            全プロジェクトの写真を管理 ({totalPhotos}枚)
+          </p>
+        </div>
+      </div>
+
+      {/* Project Photo Grid */}
+      {projects.length === 0 ? (
+        <div className="text-center py-12 bg-gray-50 dark:bg-gray-800 rounded-lg">
+          <Image className="w-12 h-12 mx-auto text-gray-400 mb-4" />
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+            写真がありません
+          </h3>
+          <p className="text-gray-500 dark:text-gray-400 mb-4">
+            プロジェクトに写真をアップロードしてください
+          </p>
+          <Link
+            href="/projects"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+          >
+            <FolderOpen className="w-4 h-4" />
+            プロジェクト一覧へ
+          </Link>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {projects.map((project) => (
+            <Link
+              key={project.id}
+              href={`/projects/${project.id}/photos`}
+              className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 hover:shadow-md transition-shadow overflow-hidden group"
+            >
+              {/* Thumbnail Grid */}
+              <div className="aspect-video bg-gray-100 dark:bg-gray-700 grid grid-cols-2 gap-0.5 p-0.5">
+                {project.photos.length > 0 ? (
+                  project.photos.map((photo, i) => (
+                    <div
+                      key={photo.id}
+                      className="bg-gray-200 dark:bg-gray-600 flex items-center justify-center"
+                    >
+                      {photo.thumbnailPath ? (
+                        <img
+                          src={photo.thumbnailPath}
+                          alt={photo.title || ''}
+                          className="w-full h-full object-cover"
+                        />
+                      ) : (
+                        <Image className="w-6 h-6 text-gray-400" />
+                      )}
+                    </div>
+                  ))
+                ) : (
+                  <div className="col-span-2 flex items-center justify-center">
+                    <Image className="w-12 h-12 text-gray-400" />
+                  </div>
+                )}
+                {project.photos.length > 0 && project.photos.length < 4 &&
+                  Array.from({ length: 4 - project.photos.length }).map((_, i) => (
+                    <div
+                      key={`empty-${i}`}
+                      className="bg-gray-200 dark:bg-gray-600 flex items-center justify-center"
+                    >
+                      <Image className="w-6 h-6 text-gray-300" />
+                    </div>
+                  ))
+                }
+              </div>
+
+              {/* Project Info */}
+              <div className="p-4">
+                <div className="flex items-center justify-between">
+                  <h3 className="font-semibold text-gray-900 dark:text-white truncate">
+                    {project.name}
+                  </h3>
+                  <ArrowRight className="w-4 h-4 text-gray-400 group-hover:text-blue-600 transition-colors" />
+                </div>
+                <div className="flex items-center gap-4 mt-2 text-sm text-gray-500 dark:text-gray-400">
+                  <span className="flex items-center gap-1">
+                    <Image className="w-4 h-4" />
+                    {project._count.photos}枚
+                  </span>
+                  {project.updatedAt && (
+                    <span className="flex items-center gap-1">
+                      <Calendar className="w-4 h-4" />
+                      {new Date(project.updatedAt).toLocaleDateString('ja-JP')}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
サイドバーのナビゲーションに対応する以下の未実装ページを新規作成:

- `/photos` - 全プロジェクトの写真一覧（プロジェクト別グリッド表示）
- `/albums` - 全プロジェクトのアルバム一覧
- `/categories` - 全プロジェクトの工種分類一覧
- `/blackboard` - 電子黒板管理ページ（テンプレート表示含む）
- `/export` - エクスポート設定ページ（電子納品・アルバム出力）

## 実装詳細
- 全ページ日本語UI
- 既存のデザインシステムに準拠
- ダークモード対応
- 空状態のUI実装
- プロジェクトへの適切なリンク

## Test plan
- [ ] サイドバーから各ページに遷移できること
- [ ] /photos - プロジェクト別の写真グリッドが表示されること
- [ ] /albums - アルバム一覧が表示されること
- [ ] /categories - 工種分類一覧が表示されること
- [ ] /blackboard - 黒板テンプレートとプロジェクト一覧が表示されること
- [ ] /export - エクスポート機能の説明とプロジェクト一覧が表示されること
- [ ] 空の状態でも適切なメッセージが表示されること
- [ ] ビルドが正常に完了すること ✅

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)