### PR TITLE
feat: 黒板保存・管理機能を追加 (#89)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,9 @@ test-results/
 
 # Claude Code
 .claude/
+
+# Local SSL certificates
+certificates/
+
+# HTTPS proxy script (local dev)
+scripts/https-proxy.mjs

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/(dashboard)/camera/CameraPageClient.tsx
+++ b/src/app/(dashboard)/camera/CameraPageClient.tsx
@@ -1,23 +1,76 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import { Camera, MapPin, Wifi, Image, FolderOpen, ChevronRight, Lock } from 'lucide-react';
+import { Camera, MapPin, Wifi, Image, FolderOpen, ChevronRight, Lock, FileText, Save } from 'lucide-react';
 import { CameraView } from '@/components/camera/CameraView';
+import { BlackboardOverlay, BlackboardOverlayState } from '@/components/camera/BlackboardOverlay';
+import { BlackboardSaveDialog } from '@/components/camera/BlackboardSaveDialog';
+import { BlackboardManager } from '@/components/camera/BlackboardManager';
 import { CapturedPhoto } from '@/hooks/useCamera';
+import { useSavedBlackboards } from '@/hooks/useSavedBlackboards';
+import type { BlackboardTemplate, BlackboardFieldValue } from '@/types/blackboard';
+import type { SavedBlackboard, SavedBlackboardInput } from '@/lib/blackboardStorage';
 
 type CameraStatus = 'checking' | 'supported' | 'not-secure' | 'not-supported';
 
+// Default blackboard template for demo
+const DEFAULT_TEMPLATE: BlackboardTemplate = {
+  id: 'default',
+  name: '標準工事黒板',
+  width: 400,
+  height: 300,
+  backgroundColor: '#1a472a',
+  borderColor: '#ffffff',
+  borderWidth: 3,
+  fields: [
+    { id: 'title', name: 'title', label: '工事名', type: 'text', required: true, x: 5, y: 5, width: 90, height: 15, fontSize: 18, fontColor: '#ffffff' },
+    { id: 'date', name: 'date', label: '撮影日', type: 'date', required: true, x: 5, y: 25, width: 45, height: 12, fontSize: 14, fontColor: '#ffffff' },
+    { id: 'location', name: 'location', label: '撮影箇所', type: 'text', required: false, x: 50, y: 25, width: 45, height: 12, fontSize: 14, fontColor: '#ffffff' },
+    { id: 'workType', name: 'workType', label: '工種', type: 'text', required: false, x: 5, y: 42, width: 45, height: 12, fontSize: 14, fontColor: '#ffffff' },
+    { id: 'contractor', name: 'contractor', label: '施工者', type: 'text', required: false, x: 50, y: 42, width: 45, height: 12, fontSize: 14, fontColor: '#ffffff' },
+    { id: 'note', name: 'note', label: '備考', type: 'text', required: false, x: 5, y: 59, width: 90, height: 35, fontSize: 14, fontColor: '#ffffff' },
+  ],
+  isDefault: true,
+  isActive: true,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
 export function CameraPageClient() {
   const router = useRouter();
+  const cameraContainerRef = useRef<HTMLDivElement>(null);
   const [isCameraOpen, setIsCameraOpen] = useState(false);
   const [capturedPhotos, setCapturedPhotos] = useState<CapturedPhoto[]>([]);
   const [cameraStatus, setCameraStatus] = useState<CameraStatus>('checking');
 
+  // Blackboard state
+  const [blackboardValues, setBlackboardValues] = useState<BlackboardFieldValue[]>([
+    { fieldId: 'title', value: '' },
+    { fieldId: 'date', value: new Date().toISOString().split('T')[0] },
+    { fieldId: 'location', value: '' },
+    { fieldId: 'workType', value: '' },
+    { fieldId: 'contractor', value: '' },
+    { fieldId: 'note', value: '' },
+  ]);
+  const [blackboardState, setBlackboardState] = useState<BlackboardOverlayState>({
+    visible: true,
+    position: 'bottom-right',
+    customPosition: { x: 20, y: 20 },
+    scale: 0.6,
+    opacity: 0.9,
+  });
+
+  // Dialogs
+  const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
+  const [isLoadDialogOpen, setIsLoadDialogOpen] = useState(false);
+
+  // Saved blackboards hook
+  const { save, blackboards } = useSavedBlackboards();
+
   // Check camera support on client side
   useEffect(() => {
     const checkCameraSupport = () => {
-      // Check if we're in a secure context (HTTPS or localhost)
       const isSecureContext =
         typeof window !== 'undefined' &&
         (window.isSecureContext ||
@@ -30,7 +83,6 @@ export function CameraPageClient() {
         return;
       }
 
-      // Check if mediaDevices API is available
       if (typeof navigator !== 'undefined' &&
           navigator.mediaDevices &&
           typeof navigator.mediaDevices.getUserMedia === 'function') {
@@ -60,14 +112,69 @@ export function CameraPageClient() {
     router.push('/projects');
   };
 
+  const handleSaveBlackboard = async (input: SavedBlackboardInput) => {
+    await save(input);
+  };
+
+  const handleLoadBlackboard = (blackboard: SavedBlackboard) => {
+    setBlackboardValues(blackboard.values);
+    setBlackboardState({
+      ...blackboardState,
+      position: blackboard.overlayState.position,
+      customPosition: blackboard.overlayState.customPosition,
+      scale: blackboard.overlayState.scale,
+      opacity: blackboard.overlayState.opacity,
+    });
+    setIsLoadDialogOpen(false);
+  };
+
+  const handleBlackboardValueChange = (fieldId: string, value: string) => {
+    setBlackboardValues(prev =>
+      prev.map(v => v.fieldId === fieldId ? { ...v, value } : v)
+    );
+  };
+
   const isCameraSupported = cameraStatus === 'supported';
 
   return (
     <>
-      {/* Camera Modal */}
+      {/* Camera Modal with Blackboard */}
       {isCameraOpen && (
-        <CameraView onCapture={handleCapture} onClose={handleCloseCamera} />
+        <CameraView
+          onCapture={handleCapture}
+          onClose={handleCloseCamera}
+          showBlackboardToggle
+          isBlackboardVisible={blackboardState.visible}
+          onBlackboardToggle={() => setBlackboardState(prev => ({ ...prev, visible: !prev.visible }))}
+          blackboardOverlay={
+            <BlackboardOverlay
+              template={DEFAULT_TEMPLATE}
+              values={blackboardValues}
+              state={blackboardState}
+              onStateChange={setBlackboardState}
+              containerRef={cameraContainerRef}
+              onSave={() => setIsSaveDialogOpen(true)}
+              onLoad={() => setIsLoadDialogOpen(true)}
+            />
+          }
+        />
       )}
+
+      {/* Save Dialog */}
+      <BlackboardSaveDialog
+        isOpen={isSaveDialogOpen}
+        onClose={() => setIsSaveDialogOpen(false)}
+        onSave={handleSaveBlackboard}
+        values={blackboardValues}
+        overlayState={blackboardState}
+      />
+
+      {/* Load Dialog */}
+      <BlackboardManager
+        isOpen={isLoadDialogOpen}
+        onClose={() => setIsLoadDialogOpen(false)}
+        onSelect={handleLoadBlackboard}
+      />
 
       <div className="space-y-6">
         {/* Header */}
@@ -130,6 +237,112 @@ export function CameraPageClient() {
           {cameraStatus === 'not-supported' && (
             <p className="mt-3 text-sm text-blue-200">
               ※ このブラウザではカメラ機能がサポートされていません
+            </p>
+          )}
+        </div>
+
+        {/* Blackboard Editor */}
+        <div className="bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+              <FileText className="w-5 h-5" />
+              黒板設定
+            </h3>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setIsLoadDialogOpen(true)}
+                className="px-3 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors flex items-center gap-1"
+              >
+                <FolderOpen className="w-4 h-4" />
+                読み込み
+              </button>
+              <button
+                onClick={() => setIsSaveDialogOpen(true)}
+                className="px-3 py-1.5 text-sm text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors flex items-center gap-1"
+              >
+                <Save className="w-4 h-4" />
+                保存
+              </button>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                工事名
+              </label>
+              <input
+                type="text"
+                value={blackboardValues.find(v => v.fieldId === 'title')?.value as string || ''}
+                onChange={(e) => handleBlackboardValueChange('title', e.target.value)}
+                placeholder="例: ○○マンション新築工事"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                撮影日
+              </label>
+              <input
+                type="date"
+                value={blackboardValues.find(v => v.fieldId === 'date')?.value as string || ''}
+                onChange={(e) => handleBlackboardValueChange('date', e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                撮影箇所
+              </label>
+              <input
+                type="text"
+                value={blackboardValues.find(v => v.fieldId === 'location')?.value as string || ''}
+                onChange={(e) => handleBlackboardValueChange('location', e.target.value)}
+                placeholder="例: 1階エントランス"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                工種
+              </label>
+              <input
+                type="text"
+                value={blackboardValues.find(v => v.fieldId === 'workType')?.value as string || ''}
+                onChange={(e) => handleBlackboardValueChange('workType', e.target.value)}
+                placeholder="例: 基礎工事"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                施工者
+              </label>
+              <input
+                type="text"
+                value={blackboardValues.find(v => v.fieldId === 'contractor')?.value as string || ''}
+                onChange={(e) => handleBlackboardValueChange('contractor', e.target.value)}
+                placeholder="例: 山田建設株式会社"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                備考
+              </label>
+              <input
+                type="text"
+                value={blackboardValues.find(v => v.fieldId === 'note')?.value as string || ''}
+                onChange={(e) => handleBlackboardValueChange('note', e.target.value)}
+                placeholder="例: 配筋検査完了"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+              />
+            </div>
+          </div>
+
+          {blackboards.length > 0 && (
+            <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+              保存済み黒板: {blackboards.length}件
             </p>
           )}
         </div>
@@ -204,15 +417,19 @@ export function CameraPageClient() {
           <ol className="space-y-2 text-sm text-gray-600 dark:text-gray-400">
             <li className="flex items-start gap-2">
               <span className="w-5 h-5 bg-blue-100 dark:bg-blue-900/50 text-blue-600 dark:text-blue-400 rounded-full flex items-center justify-center text-xs font-medium flex-shrink-0 mt-0.5">1</span>
-              <span>「カメラを起動」ボタンをタップしてカメラを開きます</span>
+              <span>黒板設定で工事名や撮影箇所を入力し、「保存」で黒板を保存</span>
             </li>
             <li className="flex items-start gap-2">
               <span className="w-5 h-5 bg-blue-100 dark:bg-blue-900/50 text-blue-600 dark:text-blue-400 rounded-full flex items-center justify-center text-xs font-medium flex-shrink-0 mt-0.5">2</span>
-              <span>被写体を画面に収め、シャッターボタンをタップして撮影</span>
+              <span>「カメラを起動」ボタンをタップしてカメラを開きます</span>
             </li>
             <li className="flex items-start gap-2">
               <span className="w-5 h-5 bg-blue-100 dark:bg-blue-900/50 text-blue-600 dark:text-blue-400 rounded-full flex items-center justify-center text-xs font-medium flex-shrink-0 mt-0.5">3</span>
-              <span>プレビューで確認し、「使用する」で保存、「撮り直す」で再撮影</span>
+              <span>黒板をドラッグで移動、タップで設定パネルを開いてサイズや位置を調整</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="w-5 h-5 bg-blue-100 dark:bg-blue-900/50 text-blue-600 dark:text-blue-400 rounded-full flex items-center justify-center text-xs font-medium flex-shrink-0 mt-0.5">4</span>
+              <span>シャッターボタンで撮影し、「使用する」で保存</span>
             </li>
           </ol>
         </div>

--- a/src/components/camera/BlackboardManager.tsx
+++ b/src/components/camera/BlackboardManager.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  X,
+  FolderOpen,
+  Trash2,
+  Star,
+  StarOff,
+  Clock,
+  ChevronRight,
+  Loader2,
+  FileText,
+} from 'lucide-react';
+import type { SavedBlackboard } from '@/lib/blackboardStorage';
+import { useSavedBlackboards } from '@/hooks/useSavedBlackboards';
+
+interface BlackboardManagerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (blackboard: SavedBlackboard) => void;
+  projectId?: string;
+  projectName?: string;
+}
+
+export function BlackboardManager({
+  isOpen,
+  onClose,
+  onSelect,
+  projectId,
+  projectName,
+}: BlackboardManagerProps) {
+  const { blackboards, isLoading, error, remove, setAsDefault } = useSavedBlackboards({
+    projectId,
+  });
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<'project' | 'global'>('project');
+
+  if (!isOpen) return null;
+
+  const projectBlackboards = blackboards.filter((b) => b.projectId === projectId);
+  const globalBlackboards = blackboards.filter((b) => !b.projectId);
+  const currentBlackboards = activeTab === 'project' ? projectBlackboards : globalBlackboards;
+
+  const formatDate = (date: Date) => {
+    const d = new Date(date);
+    return `${d.getMonth() + 1}/${d.getDate()} ${d.getHours()}:${String(d.getMinutes()).padStart(2, '0')}`;
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await remove(id);
+      setDeleteConfirm(null);
+    } catch {
+      // Error is handled by hook
+    }
+  };
+
+  const handleSetDefault = async (id: string) => {
+    try {
+      await setAsDefault(id);
+    } catch {
+      // Error is handled by hook
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg w-full max-w-lg max-h-[80vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+            <FileText className="w-5 h-5" />
+            保存済み黒板
+          </h3>
+          <button
+            onClick={onClose}
+            className="w-8 h-8 rounded-full flex items-center justify-center text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Tabs */}
+        {projectId && (
+          <div className="flex border-b border-gray-200 dark:border-gray-700">
+            <button
+              onClick={() => setActiveTab('project')}
+              className={`flex-1 px-4 py-3 text-sm font-medium transition-colors ${
+                activeTab === 'project'
+                  ? 'text-blue-600 border-b-2 border-blue-600'
+                  : 'text-gray-500 hover:text-gray-700 dark:text-gray-400'
+              }`}
+            >
+              <span className="flex items-center justify-center gap-2">
+                <FolderOpen className="w-4 h-4" />
+                {projectName || 'プロジェクト'}
+                <span className="text-xs bg-gray-100 dark:bg-gray-700 px-2 py-0.5 rounded-full">
+                  {projectBlackboards.length}
+                </span>
+              </span>
+            </button>
+            <button
+              onClick={() => setActiveTab('global')}
+              className={`flex-1 px-4 py-3 text-sm font-medium transition-colors ${
+                activeTab === 'global'
+                  ? 'text-blue-600 border-b-2 border-blue-600'
+                  : 'text-gray-500 hover:text-gray-700 dark:text-gray-400'
+              }`}
+            >
+              <span className="flex items-center justify-center gap-2">
+                共通テンプレート
+                <span className="text-xs bg-gray-100 dark:bg-gray-700 px-2 py-0.5 rounded-full">
+                  {globalBlackboards.length}
+                </span>
+              </span>
+            </button>
+          </div>
+        )}
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="w-8 h-8 text-gray-400 animate-spin" />
+            </div>
+          ) : error ? (
+            <div className="text-center py-12">
+              <p className="text-red-500">{error}</p>
+            </div>
+          ) : currentBlackboards.length === 0 ? (
+            <div className="text-center py-12">
+              <FileText className="w-12 h-12 text-gray-300 dark:text-gray-600 mx-auto mb-4" />
+              <p className="text-gray-500 dark:text-gray-400">
+                {activeTab === 'project'
+                  ? 'このプロジェクトに保存された黒板はありません'
+                  : '共通テンプレートはありません'}
+              </p>
+              <p className="text-sm text-gray-400 dark:text-gray-500 mt-2">
+                カメラ画面で黒板を保存すると、ここに表示されます
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {currentBlackboards.map((blackboard) => (
+                <div
+                  key={blackboard.id}
+                  className="bg-gray-50 dark:bg-gray-700/50 rounded-lg overflow-hidden"
+                >
+                  {deleteConfirm === blackboard.id ? (
+                    // Delete confirmation
+                    <div className="p-4">
+                      <p className="text-sm text-gray-700 dark:text-gray-300 mb-3">
+                        「{blackboard.name}」を削除しますか？
+                      </p>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => setDeleteConfirm(null)}
+                          className="flex-1 px-3 py-2 text-sm bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-500 transition-colors"
+                        >
+                          キャンセル
+                        </button>
+                        <button
+                          onClick={() => handleDelete(blackboard.id)}
+                          className="flex-1 px-3 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+                        >
+                          削除
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    // Normal view
+                    <div className="flex items-center">
+                      <button
+                        onClick={() => onSelect(blackboard)}
+                        className="flex-1 p-4 text-left hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                      >
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium text-gray-900 dark:text-white">
+                                {blackboard.name}
+                              </span>
+                              {blackboard.isDefault && (
+                                <Star className="w-4 h-4 text-yellow-500 fill-yellow-500" />
+                              )}
+                            </div>
+                            <div className="flex items-center gap-3 mt-1 text-xs text-gray-500 dark:text-gray-400">
+                              <span className="flex items-center gap-1">
+                                <Clock className="w-3 h-3" />
+                                {formatDate(blackboard.updatedAt)}
+                              </span>
+                              <span>{blackboard.values.length}項目</span>
+                            </div>
+                          </div>
+                          <ChevronRight className="w-5 h-5 text-gray-400" />
+                        </div>
+                      </button>
+
+                      {/* Actions */}
+                      <div className="flex items-center gap-1 pr-2">
+                        {projectId && activeTab === 'project' && !blackboard.isDefault && (
+                          <button
+                            onClick={() => handleSetDefault(blackboard.id)}
+                            className="w-8 h-8 rounded-full flex items-center justify-center text-gray-400 hover:text-yellow-500 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                            title="デフォルトに設定"
+                          >
+                            <StarOff className="w-4 h-4" />
+                          </button>
+                        )}
+                        <button
+                          onClick={() => setDeleteConfirm(blackboard.id)}
+                          className="w-8 h-8 rounded-full flex items-center justify-center text-gray-400 hover:text-red-500 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                          title="削除"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="p-4 border-t border-gray-200 dark:border-gray-700">
+          <button
+            onClick={onClose}
+            className="w-full px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
+          >
+            閉じる
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/camera/BlackboardOverlay.tsx
+++ b/src/components/camera/BlackboardOverlay.tsx
@@ -11,6 +11,8 @@ import {
   CornerDownRight,
   CornerUpLeft,
   CornerUpRight,
+  Save,
+  FolderOpen,
 } from 'lucide-react';
 import type { BlackboardTemplate, BlackboardFieldValue } from '@/types/blackboard';
 import { drawBlackboard } from '@/lib/blackboard';
@@ -31,6 +33,8 @@ interface BlackboardOverlayProps {
   state: BlackboardOverlayState;
   onStateChange: (state: BlackboardOverlayState) => void;
   containerRef?: React.RefObject<HTMLElement | null>;
+  onSave?: () => void;
+  onLoad?: () => void;
 }
 
 const POSITION_PRESETS = {
@@ -46,6 +50,8 @@ export function BlackboardOverlay({
   state,
   onStateChange,
   containerRef,
+  onSave,
+  onLoad,
 }: BlackboardOverlayProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -274,6 +280,36 @@ export function BlackboardOverlay({
               </span>
             </div>
           </div>
+
+          {/* Save/Load buttons */}
+          {(onSave || onLoad) && (
+            <div className="flex items-center gap-2 mt-3 pt-3 border-t border-gray-600">
+              {onLoad && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onLoad();
+                  }}
+                  className="flex-1 py-2 bg-gray-700 text-white text-xs rounded hover:bg-gray-600 transition-colors flex items-center justify-center gap-1"
+                >
+                  <FolderOpen className="w-4 h-4" />
+                  読み込み
+                </button>
+              )}
+              {onSave && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSave();
+                  }}
+                  className="flex-1 py-2 bg-blue-600 text-white text-xs rounded hover:bg-blue-700 transition-colors flex items-center justify-center gap-1"
+                >
+                  <Save className="w-4 h-4" />
+                  保存
+                </button>
+              )}
+            </div>
+          )}
 
           {/* Close button */}
           <button

--- a/src/components/camera/BlackboardSaveDialog.tsx
+++ b/src/components/camera/BlackboardSaveDialog.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useState } from 'react';
+import { X, Save, FolderOpen } from 'lucide-react';
+import type { BlackboardFieldValue } from '@/types/blackboard';
+import type { BlackboardOverlayState } from './BlackboardOverlay';
+import type { SavedBlackboardInput } from '@/lib/blackboardStorage';
+
+interface BlackboardSaveDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (input: SavedBlackboardInput) => Promise<void>;
+  values: BlackboardFieldValue[];
+  overlayState: BlackboardOverlayState;
+  projectId?: string;
+  projectName?: string;
+  existingName?: string;
+}
+
+export function BlackboardSaveDialog({
+  isOpen,
+  onClose,
+  onSave,
+  values,
+  overlayState,
+  projectId,
+  projectName,
+  existingName,
+}: BlackboardSaveDialogProps) {
+  const [name, setName] = useState(existingName || '');
+  const [saveToProject, setSaveToProject] = useState(!!projectId);
+  const [isDefault, setIsDefault] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isOpen) return null;
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      setError('黒板名を入力してください');
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      await onSave({
+        name: name.trim(),
+        projectId: saveToProject ? projectId : undefined,
+        values,
+        overlayState: {
+          position: overlayState.position,
+          customPosition: overlayState.customPosition,
+          scale: overlayState.scale,
+          opacity: overlayState.opacity,
+        },
+        isDefault,
+      });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '保存に失敗しました');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg w-full max-w-md">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+            <Save className="w-5 h-5" />
+            黒板を保存
+          </h3>
+          <button
+            onClick={onClose}
+            className="w-8 h-8 rounded-full flex items-center justify-center text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-4 space-y-4">
+          {/* Name input */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              黒板名 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="例: 基礎工事用黒板"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              autoFocus
+            />
+          </div>
+
+          {/* Project association */}
+          {projectId && (
+            <div className="space-y-2">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={saveToProject}
+                  onChange={(e) => setSaveToProject(e.target.checked)}
+                  className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <span className="text-sm text-gray-700 dark:text-gray-300">
+                  プロジェクトに紐付ける
+                </span>
+              </label>
+              {saveToProject && (
+                <div className="ml-6 flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+                  <FolderOpen className="w-4 h-4" />
+                  {projectName || projectId}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Set as default */}
+          {projectId && saveToProject && (
+            <div>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={isDefault}
+                  onChange={(e) => setIsDefault(e.target.checked)}
+                  className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <span className="text-sm text-gray-700 dark:text-gray-300">
+                  このプロジェクトのデフォルトにする
+                </span>
+              </label>
+            </div>
+          )}
+
+          {/* Saved settings info */}
+          <div className="p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">保存される設定:</p>
+            <ul className="text-xs text-gray-600 dark:text-gray-300 space-y-1">
+              <li>• 黒板の入力内容（工事名、工種など）</li>
+              <li>• 黒板の位置、サイズ、透明度</li>
+            </ul>
+          </div>
+
+          {/* Error */}
+          {error && (
+            <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 p-4 border-t border-gray-200 dark:border-gray-700">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={isSaving || !name.trim()}
+            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+          >
+            {isSaving ? (
+              <>
+                <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                保存中...
+              </>
+            ) : (
+              <>
+                <Save className="w-4 h-4" />
+                保存
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useSavedBlackboards.ts
+++ b/src/hooks/useSavedBlackboards.ts
@@ -1,0 +1,152 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { blackboardStorage, SavedBlackboard, SavedBlackboardInput } from '@/lib/blackboardStorage';
+
+interface UseSavedBlackboardsOptions {
+  projectId?: string;
+  autoLoad?: boolean;
+}
+
+interface UseSavedBlackboardsReturn {
+  blackboards: SavedBlackboard[];
+  isLoading: boolean;
+  error: string | null;
+  save: (input: SavedBlackboardInput) => Promise<string>;
+  update: (id: string, updates: Partial<SavedBlackboardInput>) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+  load: (id: string) => Promise<SavedBlackboard | null>;
+  setAsDefault: (id: string) => Promise<void>;
+  getDefault: () => Promise<SavedBlackboard | null>;
+  refresh: () => Promise<void>;
+}
+
+export function useSavedBlackboards(
+  options: UseSavedBlackboardsOptions = {}
+): UseSavedBlackboardsReturn {
+  const { projectId, autoLoad = true } = options;
+  const [blackboards, setBlackboards] = useState<SavedBlackboard[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load blackboards
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      let results: SavedBlackboard[];
+
+      if (projectId) {
+        // Get project-specific + global blackboards
+        const [projectBoards, globalBoards] = await Promise.all([
+          blackboardStorage.getBlackboardsByProject(projectId),
+          blackboardStorage.getGlobalBlackboards(),
+        ]);
+        results = [...projectBoards, ...globalBoards];
+      } else {
+        results = await blackboardStorage.getAllBlackboards();
+      }
+
+      setBlackboards(results);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '黒板の読み込みに失敗しました');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [projectId]);
+
+  // Auto load on mount
+  useEffect(() => {
+    if (autoLoad) {
+      refresh();
+    }
+  }, [autoLoad, refresh]);
+
+  // Save new blackboard
+  const save = useCallback(async (input: SavedBlackboardInput): Promise<string> => {
+    try {
+      const id = await blackboardStorage.saveBlackboard(input);
+      await refresh();
+      return id;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '黒板の保存に失敗しました';
+      setError(message);
+      throw err;
+    }
+  }, [refresh]);
+
+  // Update existing blackboard
+  const update = useCallback(async (id: string, updates: Partial<SavedBlackboardInput>): Promise<void> => {
+    try {
+      await blackboardStorage.updateBlackboard(id, updates);
+      await refresh();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '黒板の更新に失敗しました';
+      setError(message);
+      throw err;
+    }
+  }, [refresh]);
+
+  // Delete blackboard
+  const remove = useCallback(async (id: string): Promise<void> => {
+    try {
+      await blackboardStorage.deleteBlackboard(id);
+      await refresh();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '黒板の削除に失敗しました';
+      setError(message);
+      throw err;
+    }
+  }, [refresh]);
+
+  // Load specific blackboard
+  const load = useCallback(async (id: string): Promise<SavedBlackboard | null> => {
+    try {
+      return await blackboardStorage.getBlackboard(id);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '黒板の読み込みに失敗しました';
+      setError(message);
+      throw err;
+    }
+  }, []);
+
+  // Set as default for project
+  const setAsDefault = useCallback(async (id: string): Promise<void> => {
+    if (!projectId) {
+      throw new Error('プロジェクトが選択されていません');
+    }
+
+    try {
+      await blackboardStorage.setProjectDefault(projectId, id);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'デフォルト設定に失敗しました';
+      setError(message);
+      throw err;
+    }
+  }, [projectId]);
+
+  // Get default blackboard for project
+  const getDefault = useCallback(async (): Promise<SavedBlackboard | null> => {
+    if (!projectId) return null;
+
+    try {
+      return await blackboardStorage.getProjectDefault(projectId);
+    } catch (err) {
+      return null;
+    }
+  }, [projectId]);
+
+  return {
+    blackboards,
+    isLoading,
+    error,
+    save,
+    update,
+    remove,
+    load,
+    setAsDefault,
+    getDefault,
+    refresh,
+  };
+}

--- a/src/lib/blackboardStorage.ts
+++ b/src/lib/blackboardStorage.ts
@@ -1,0 +1,368 @@
+/**
+ * Blackboard Storage Utility
+ * IndexedDB wrapper for saved blackboard templates and configurations
+ */
+
+import type { BlackboardFieldValue } from '@/types/blackboard';
+
+export type { BlackboardFieldValue };
+
+const DB_NAME = 'photomanagement-blackboard';
+const DB_VERSION = 1;
+const SAVED_BOARDS_STORE = 'saved-blackboards';
+const PROJECT_DEFAULTS_STORE = 'project-defaults';
+
+/**
+ * Saved blackboard configuration
+ */
+export interface SavedBlackboard {
+  id: string;
+  name: string;
+  projectId?: string;
+  values: BlackboardFieldValue[];
+  overlayState: {
+    position: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'custom';
+    customPosition: { x: number; y: number };
+    scale: number;
+    opacity: number;
+  };
+  isDefault: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Project default blackboard mapping
+ */
+export interface ProjectDefaultBlackboard {
+  projectId: string;
+  blackboardId: string;
+  updatedAt: Date;
+}
+
+export type SavedBlackboardInput = Omit<SavedBlackboard, 'id' | 'createdAt' | 'updatedAt'>;
+
+class BlackboardStorageManager {
+  private db: IDBDatabase | null = null;
+  private dbPromise: Promise<IDBDatabase> | null = null;
+
+  /**
+   * Open the database connection
+   */
+  private async openDB(): Promise<IDBDatabase> {
+    if (this.db) return this.db;
+    if (this.dbPromise) return this.dbPromise;
+
+    this.dbPromise = new Promise((resolve, reject) => {
+      if (typeof indexedDB === 'undefined') {
+        reject(new Error('IndexedDB is not supported'));
+        return;
+      }
+
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+      request.onerror = () => {
+        reject(new Error('Failed to open blackboard database'));
+      };
+
+      request.onsuccess = () => {
+        this.db = request.result;
+        resolve(request.result);
+      };
+
+      request.onupgradeneeded = (event) => {
+        const db = (event.target as IDBOpenDBRequest).result;
+
+        // Create saved blackboards store
+        if (!db.objectStoreNames.contains(SAVED_BOARDS_STORE)) {
+          const store = db.createObjectStore(SAVED_BOARDS_STORE, { keyPath: 'id' });
+          store.createIndex('projectId', 'projectId', { unique: false });
+          store.createIndex('name', 'name', { unique: false });
+          store.createIndex('isDefault', 'isDefault', { unique: false });
+          store.createIndex('createdAt', 'createdAt', { unique: false });
+        }
+
+        // Create project defaults store
+        if (!db.objectStoreNames.contains(PROJECT_DEFAULTS_STORE)) {
+          const store = db.createObjectStore(PROJECT_DEFAULTS_STORE, { keyPath: 'projectId' });
+          store.createIndex('blackboardId', 'blackboardId', { unique: false });
+        }
+      };
+    });
+
+    return this.dbPromise;
+  }
+
+  /**
+   * Generate a unique ID
+   */
+  private generateId(): string {
+    return `bb_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+  }
+
+  /**
+   * Save a new blackboard
+   */
+  async saveBlackboard(input: SavedBlackboardInput): Promise<string> {
+    const db = await this.openDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(SAVED_BOARDS_STORE, 'readwrite');
+      const store = tx.objectStore(SAVED_BOARDS_STORE);
+
+      const now = new Date();
+      const id = this.generateId();
+      const blackboard: SavedBlackboard = {
+        ...input,
+        id,
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      const request = store.add(blackboard);
+
+      request.onsuccess = () => {
+        resolve(id);
+      };
+
+      request.onerror = () => {
+        reject(new Error('黒板の保存に失敗しました'));
+      };
+    });
+  }
+
+  /**
+   * Update an existing blackboard
+   */
+  async updateBlackboard(id: string, updates: Partial<SavedBlackboardInput>): Promise<void> {
+    const db = await this.openDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(SAVED_BOARDS_STORE, 'readwrite');
+      const store = tx.objectStore(SAVED_BOARDS_STORE);
+      const getRequest = store.get(id);
+
+      getRequest.onsuccess = () => {
+        const existing = getRequest.result as SavedBlackboard;
+        if (!existing) {
+          reject(new Error('黒板が見つかりません'));
+          return;
+        }
+
+        const updated: SavedBlackboard = {
+          ...existing,
+          ...updates,
+          updatedAt: new Date(),
+        };
+
+        const putRequest = store.put(updated);
+        putRequest.onsuccess = () => resolve();
+        putRequest.onerror = () => reject(new Error('黒板の更新に失敗しました'));
+      };
+
+      getRequest.onerror = () => {
+        reject(new Error('黒板の取得に失敗しました'));
+      };
+    });
+  }
+
+  /**
+   * Get a blackboard by ID
+   */
+  async getBlackboard(id: string): Promise<SavedBlackboard | null> {
+    const db = await this.openDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(SAVED_BOARDS_STORE, 'readonly');
+      const store = tx.objectStore(SAVED_BOARDS_STORE);
+      const request = store.get(id);
+
+      request.onsuccess = () => {
+        resolve(request.result || null);
+      };
+
+      request.onerror = () => {
+        reject(new Error('黒板の取得に失敗しました'));
+      };
+    });
+  }
+
+  /**
+   * Get all saved blackboards
+   */
+  async getAllBlackboards(): Promise<SavedBlackboard[]> {
+    const db = await this.openDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(SAVED_BOARDS_STORE, 'readonly');
+      const store = tx.objectStore(SAVED_BOARDS_STORE);
+      const request = store.getAll();
+
+      request.onsuccess = () => {
+        const results = request.result || [];
+        // Sort by updatedAt desc
+        results.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+        resolve(results);
+      };
+
+      request.onerror = () => {
+        reject(new Error('黒板一覧の取得に失敗しました'));
+      };
+    });
+  }
+
+  /**
+   * Get blackboards by project ID
+   */
+  async getBlackboardsByProject(projectId: string): Promise<SavedBlackboard[]> {
+    const db = await this.openDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(SAVED_BOARDS_STORE, 'readonly');
+      const store = tx.objectStore(SAVED_BOARDS_STORE);
+      const index = store.index('projectId');
+      const request = index.getAll(projectId);
+
+      request.onsuccess = () => {
+        const results = request.result || [];
+        results.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+        resolve(results);
+      };
+
+      request.onerror = () => {
+        reject(new Error('プロジェクトの黒板取得に失敗しました'));
+      };
+    });
+  }
+
+  /**
+   * Get global blackboards (not tied to any project)
+   */
+  async getGlobalBlackboards(): Promise<SavedBlackboard[]> {
+    const all = await this.getAllBlackboards();
+    return all.filter(b => !b.projectId);
+  }
+
+  /**
+   * Delete a blackboard
+   */
+  async deleteBlackboard(id: string): Promise<void> {
+    const db = await this.openDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(SAVED_BOARDS_STORE, 'readwrite');
+      const store = tx.objectStore(SAVED_BOARDS_STORE);
+      const request = store.delete(id);
+
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(new Error('黒板の削除に失敗しました'));
+    });
+  }
+
+  /**
+   * Set project default blackboard
+   */
+  async setProjectDefault(projectId: string, blackboardId: string): Promise<void> {
+    const db = await this.openDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(PROJECT_DEFAULTS_STORE, 'readwrite');
+      const store = tx.objectStore(PROJECT_DEFAULTS_STORE);
+
+      const record: ProjectDefaultBlackboard = {
+        projectId,
+        blackboardId,
+        updatedAt: new Date(),
+      };
+
+      const request = store.put(record);
+
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(new Error('デフォルト黒板の設定に失敗しました'));
+    });
+  }
+
+  /**
+   * Get project default blackboard
+   */
+  async getProjectDefault(projectId: string): Promise<SavedBlackboard | null> {
+    const db = await this.openDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(PROJECT_DEFAULTS_STORE, 'readonly');
+      const store = tx.objectStore(PROJECT_DEFAULTS_STORE);
+      const request = store.get(projectId);
+
+      request.onsuccess = async () => {
+        const mapping = request.result as ProjectDefaultBlackboard | undefined;
+        if (mapping) {
+          const blackboard = await this.getBlackboard(mapping.blackboardId);
+          resolve(blackboard);
+        } else {
+          resolve(null);
+        }
+      };
+
+      request.onerror = () => {
+        reject(new Error('デフォルト黒板の取得に失敗しました'));
+      };
+    });
+  }
+
+  /**
+   * Remove project default blackboard
+   */
+  async removeProjectDefault(projectId: string): Promise<void> {
+    const db = await this.openDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(PROJECT_DEFAULTS_STORE, 'readwrite');
+      const store = tx.objectStore(PROJECT_DEFAULTS_STORE);
+      const request = store.delete(projectId);
+
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(new Error('デフォルト設定の削除に失敗しました'));
+    });
+  }
+
+  /**
+   * Get statistics
+   */
+  async getStats(): Promise<{
+    total: number;
+    byProject: Map<string, number>;
+    global: number;
+  }> {
+    const all = await this.getAllBlackboards();
+    const byProject = new Map<string, number>();
+    let global = 0;
+
+    all.forEach(b => {
+      if (b.projectId) {
+        byProject.set(b.projectId, (byProject.get(b.projectId) || 0) + 1);
+      } else {
+        global++;
+      }
+    });
+
+    return {
+      total: all.length,
+      byProject,
+      global,
+    };
+  }
+
+  /**
+   * Close database connection
+   */
+  close(): void {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+      this.dbPromise = null;
+    }
+  }
+}
+
+// Export singleton instance
+export const blackboardStorage = new BlackboardStorageManager();


### PR DESCRIPTION
## Summary

- 黒板の保存・読み込み機能を追加
- プロジェクト別黒板管理機能を実装  
- IndexedDBによるオフライン対応の永続化

### 新規ファイル
- `src/lib/blackboardStorage.ts`: IndexedDB ストレージマネージャー
- `src/hooks/useSavedBlackboards.ts`: 保存済み黒板管理フック
- `src/components/camera/BlackboardSaveDialog.tsx`: 保存ダイアログ
- `src/components/camera/BlackboardManager.tsx`: 黒板一覧・選択UI

### 機能
- 黒板の保存ボタン（名前付けて保存）
- 保存した黒板の一覧表示・読み込み
- プロジェクト別/共通テンプレートの切り替え
- デフォルト黒板の設定

## Test plan

- [ ] カメラページで黒板設定を入力し「保存」ボタンで保存できることを確認
- [ ] 「読み込み」で保存した黒板を選択し、値が反映されることを確認
- [ ] カメラ起動時の黒板オーバーレイから保存/読み込みができることを確認
- [ ] ブラウザリロード後も保存した黒板が残っていることを確認

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)