### PR TITLE
feat: Capacitor Camera APIに移行

### DIFF
--- a/src/lib/capacitor/camera.ts
+++ b/src/lib/capacitor/camera.ts
@@ -1,0 +1,193 @@
+/**
+ * Capacitor Camera API ユーティリティ
+ * ネイティブアプリでは Capacitor Camera を使用し、Webでは getUserMedia にフォールバック
+ */
+
+import { Camera, CameraResultType, CameraSource, Photo } from '@capacitor/camera';
+import { Capacitor } from '@capacitor/core';
+
+export interface CapacitorPhotoResult {
+  dataUrl: string;
+  format: string;
+  saved: boolean;
+  webPath?: string;
+}
+
+export interface CaptureOptions {
+  quality?: number;
+  allowEditing?: boolean;
+  resultType?: CameraResultType;
+  source?: CameraSource;
+  width?: number;
+  height?: number;
+  correctOrientation?: boolean;
+  saveToGallery?: boolean;
+  promptLabelHeader?: string;
+  promptLabelCancel?: string;
+  promptLabelPhoto?: string;
+  promptLabelPicture?: string;
+}
+
+/**
+ * Capacitor Camera が利用可能かチェック
+ */
+export const isCapacitorCameraAvailable = (): boolean => {
+  return Capacitor.isNativePlatform() && Capacitor.isPluginAvailable('Camera');
+};
+
+/**
+ * カメラ権限をリクエスト
+ */
+export const requestCameraPermission = async (): Promise<boolean> => {
+  try {
+    const permission = await Camera.requestPermissions({
+      permissions: ['camera'],
+    });
+    return permission.camera === 'granted';
+  } catch (error) {
+    console.error('[CapacitorCamera] Permission request failed:', error);
+    return false;
+  }
+};
+
+/**
+ * カメラ権限の状態を確認
+ */
+export const checkCameraPermission = async (): Promise<'granted' | 'denied' | 'prompt'> => {
+  try {
+    const permission = await Camera.checkPermissions();
+    const state = permission.camera;
+    // 'prompt-with-rationale' は 'prompt' として扱う
+    if (state === 'granted' || state === 'denied') {
+      return state;
+    }
+    return 'prompt';
+  } catch {
+    return 'prompt';
+  }
+};
+
+/**
+ * Capacitor Camera で写真を撮影
+ */
+export const captureWithCapacitorCamera = async (
+  options: CaptureOptions = {}
+): Promise<CapacitorPhotoResult | null> => {
+  const {
+    quality = 92,
+    allowEditing = false,
+    resultType = CameraResultType.DataUrl,
+    source = CameraSource.Camera,
+    width,
+    height,
+    correctOrientation = true,
+    saveToGallery = false,
+    promptLabelHeader = '写真',
+    promptLabelCancel = 'キャンセル',
+    promptLabelPhoto = 'フォトライブラリ',
+    promptLabelPicture = '写真を撮る',
+  } = options;
+
+  try {
+    const photo: Photo = await Camera.getPhoto({
+      quality,
+      allowEditing,
+      resultType,
+      source,
+      width,
+      height,
+      correctOrientation,
+      saveToGallery,
+      promptLabelHeader,
+      promptLabelCancel,
+      promptLabelPhoto,
+      promptLabelPicture,
+    });
+
+    // DataUrl の場合
+    if (resultType === CameraResultType.DataUrl && photo.dataUrl) {
+      return {
+        dataUrl: photo.dataUrl,
+        format: photo.format,
+        saved: photo.saved || false,
+        webPath: photo.webPath,
+      };
+    }
+
+    // Base64 の場合は DataUrl に変換
+    if (resultType === CameraResultType.Base64 && photo.base64String) {
+      return {
+        dataUrl: `data:image/${photo.format};base64,${photo.base64String}`,
+        format: photo.format,
+        saved: photo.saved || false,
+        webPath: photo.webPath,
+      };
+    }
+
+    // Uri の場合
+    if (resultType === CameraResultType.Uri && photo.webPath) {
+      return {
+        dataUrl: photo.webPath,
+        format: photo.format,
+        saved: photo.saved || false,
+        webPath: photo.webPath,
+      };
+    }
+
+    return null;
+  } catch (error) {
+    // ユーザーがキャンセルした場合
+    if (error instanceof Error && error.message.includes('cancelled')) {
+      console.log('[CapacitorCamera] User cancelled');
+      return null;
+    }
+    console.error('[CapacitorCamera] Capture failed:', error);
+    throw error;
+  }
+};
+
+/**
+ * フォトライブラリから写真を選択
+ */
+export const pickFromGallery = async (
+  options: Omit<CaptureOptions, 'source'> = {}
+): Promise<CapacitorPhotoResult | null> => {
+  return captureWithCapacitorCamera({
+    ...options,
+    source: CameraSource.Photos,
+  });
+};
+
+/**
+ * カメラまたはフォトライブラリから選択（プロンプト表示）
+ */
+export const captureWithPrompt = async (
+  options: Omit<CaptureOptions, 'source'> = {}
+): Promise<CapacitorPhotoResult | null> => {
+  return captureWithCapacitorCamera({
+    ...options,
+    source: CameraSource.Prompt,
+  });
+};
+
+/**
+ * DataUrl から Blob を作成
+ */
+export const dataUrlToBlob = async (dataUrl: string): Promise<Blob> => {
+  const response = await fetch(dataUrl);
+  return response.blob();
+};
+
+/**
+ * 写真のサイズを取得
+ */
+export const getPhotoSize = (dataUrl: string): Promise<{ width: number; height: number }> => {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      resolve({ width: img.naturalWidth, height: img.naturalHeight });
+    };
+    img.onerror = reject;
+    img.src = dataUrl;
+  });
+};


### PR DESCRIPTION
## Summary
- ネイティブアプリでCapacitor Camera APIを使用するようカメラ機能を移行
- Web版は従来のgetUserMedia APIを維持（黒板オーバーレイ機能のため）
- ハイブリッドアプローチで両環境をサポート

## Changes

### `src/lib/capacitor/camera.ts` (新規)
Capacitor Camera APIユーティリティ関数を追加:
- `isCapacitorCameraAvailable()`: ネイティブカメラ利用可能判定
- `requestCameraPermission()`: カメラ権限リクエスト
- `captureWithCapacitorCamera()`: ネイティブカメラで撮影
- `pickFromGallery()`: フォトライブラリから選択
- `dataUrlToBlob()`, `getPhotoSize()`: ヘルパー関数

### `src/hooks/useCamera.ts`
ハイブリッド対応に更新:
- ネイティブ環境: Capacitor Camera APIを使用
- Web環境: getUserMedia APIを維持
- `useWebCameraOnly` オプション追加（黒板オーバーレイ用）
- `isNativeCamera` フラグ追加
- `captureWithNativeCamera()` 関数追加

### `src/components/camera/CameraView.tsx`
UI更新:
- ネイティブカメラモード用の専用UIを追加
- `useWebCameraOnly` プロパティ追加

## Native Camera Mode
ネイティブアプリでは:
- 「カメラを起動」ボタンをタップ → OSのカメラUIが開く
- 撮影後、プレビュー画面で確認/撮り直し

## Test plan
- [ ] Webブラウザで従来通りのカメラ機能が動作すること
- [ ] iOS実機/シミュレーターでネイティブカメラが起動すること
- [ ] Android実機/エミュレーターでネイティブカメラが起動すること
- [ ] 黒板オーバーレイ使用時はWebカメラが使用されること
- [ ] 撮影した写真が正しく処理されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)