### PR TITLE
feat: Lark Base連携機能を追加 (#96)

### DIFF
--- a/src/app/api/lark/config/route.ts
+++ b/src/app/api/lark/config/route.ts
@@ -1,0 +1,31 @@
+/**
+ * Lark Base設定チェックAPI
+ */
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { isLarkConfigured } from '@/lib/lark/client';
+
+export async function GET() {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json(
+        { success: false, error: '認証が必要です' },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        configured: isLarkConfigured(),
+      },
+    });
+  } catch (error) {
+    console.error('Lark config check error:', error);
+    return NextResponse.json(
+      { success: false, error: '設定チェックに失敗しました' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/lark/records/route.ts
+++ b/src/app/api/lark/records/route.ts
@@ -1,0 +1,87 @@
+/**
+ * Lark Baseレコード検索API
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import {
+  isLarkConfigured,
+  searchRecords,
+  buildSearchFilter,
+  mapRecordToProject,
+  getDefaultMapping,
+} from '@/lib/lark/client';
+import type { LarkApiResponse, LarkProjectData } from '@/lib/lark/types';
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json(
+        { success: false, error: '認証が必要です' },
+        { status: 401 }
+      );
+    }
+
+    if (!isLarkConfigured()) {
+      return NextResponse.json(
+        { success: false, error: 'Lark Base連携が設定されていません' },
+        { status: 400 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const search = searchParams.get('search') || '';
+    const pageSize = parseInt(searchParams.get('pageSize') || '20', 10);
+    const pageToken = searchParams.get('pageToken') || undefined;
+
+    const mapping = getDefaultMapping();
+    const searchFields = [
+      mapping.nameField,
+      mapping.codeField,
+      mapping.clientNameField,
+    ].filter((f): f is string => !!f);
+
+    const filter = search ? buildSearchFilter(search, searchFields) : undefined;
+
+    const response = await searchRecords({
+      page_size: pageSize,
+      page_token: pageToken,
+      filter,
+    });
+
+    const records: LarkProjectData[] = [];
+    for (const item of response.data.items) {
+      try {
+        records.push(mapRecordToProject(item, mapping));
+      } catch (e) {
+        console.warn('Failed to map record:', item.record_id, e);
+      }
+    }
+
+    const result: LarkApiResponse<{
+      records: LarkProjectData[];
+      hasMore: boolean;
+      pageToken?: string;
+      total: number;
+    }> = {
+      success: true,
+      data: {
+        records,
+        hasMore: response.data.has_more,
+        pageToken: response.data.page_token,
+        total: response.data.total,
+      },
+    };
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('Lark records search error:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'レコード取得に失敗しました',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/projects/LarkBaseImportDialog.tsx
+++ b/src/components/projects/LarkBaseImportDialog.tsx
@@ -1,0 +1,428 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Search,
+  X,
+  Loader2,
+  AlertCircle,
+  Database,
+  Calendar,
+  MapPin,
+  ChevronDown,
+  Check,
+} from 'lucide-react';
+import type { LarkProjectData } from '@/lib/lark/types';
+
+interface LarkBaseImportDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onImport: (project: LarkProjectData) => void;
+}
+
+/**
+ * Fetch projects from Lark Base API
+ */
+async function fetchLarkProjects(
+  query: string,
+  pageToken?: string
+): Promise<{ projects: LarkProjectData[]; hasMore: boolean; pageToken?: string }> {
+  const params = new URLSearchParams();
+  if (query) params.set('search', query);
+  if (pageToken) params.set('pageToken', pageToken);
+  params.set('pageSize', '20');
+
+  const response = await fetch(`/api/lark/records?${params.toString()}`);
+
+  if (!response.ok) {
+    throw new Error('Lark Baseからのデータ取得に失敗しました');
+  }
+
+  const result = await response.json();
+
+  if (!result.success) {
+    throw new Error(result.error || 'Lark Baseからのデータ取得に失敗しました');
+  }
+
+  return {
+    projects: result.data.records,
+    hasMore: result.data.hasMore,
+    pageToken: result.data.pageToken,
+  };
+}
+
+/**
+ * Lark Base Import Dialog Component
+ *
+ * Modal dialog for searching and importing projects from Lark Base:
+ * - Search input with debounce
+ * - Search results displayed as cards
+ * - Selection and import functionality
+ * - Loading and error state display
+ * - "Load more" pagination
+ */
+export function LarkBaseImportDialog({
+  isOpen,
+  onClose,
+  onImport,
+}: LarkBaseImportDialogProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [projects, setProjects] = useState<LarkProjectData[]>([]);
+  const [selectedProject, setSelectedProject] = useState<LarkProjectData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [pageToken, setPageToken] = useState<string | undefined>(undefined);
+  const [importing, setImporting] = useState(false);
+
+  /**
+   * Debounce search query
+   */
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedQuery(searchQuery);
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  /**
+   * Fetch projects when debounced query changes
+   */
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const fetchProjectsAsync = async () => {
+      setLoading(true);
+      setError(null);
+      setPageToken(undefined);
+      setSelectedProject(null);
+
+      try {
+        const result = await fetchLarkProjects(debouncedQuery);
+        setProjects(result.projects);
+        setHasMore(result.hasMore);
+        setPageToken(result.pageToken);
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Lark Baseからのデータ取得に失敗しました'
+        );
+        setProjects([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProjectsAsync();
+  }, [debouncedQuery, isOpen]);
+
+  /**
+   * Load more projects
+   */
+  const handleLoadMore = useCallback(async () => {
+    if (loadingMore || !hasMore || !pageToken) return;
+
+    setLoadingMore(true);
+    setError(null);
+
+    try {
+      const result = await fetchLarkProjects(debouncedQuery, pageToken);
+      setProjects((prev) => [...prev, ...result.projects]);
+      setHasMore(result.hasMore);
+      setPageToken(result.pageToken);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : '追加データの取得に失敗しました'
+      );
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [debouncedQuery, hasMore, loadingMore, pageToken]);
+
+  /**
+   * Handle project selection
+   */
+  const handleSelect = useCallback((project: LarkProjectData) => {
+    setSelectedProject((prev) => (prev?.recordId === project.recordId ? null : project));
+  }, []);
+
+  /**
+   * Handle import
+   */
+  const handleImport = useCallback(async () => {
+    if (!selectedProject) return;
+
+    setImporting(true);
+    try {
+      await onImport(selectedProject);
+      onClose();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'インポートに失敗しました'
+      );
+    } finally {
+      setImporting(false);
+    }
+  }, [selectedProject, onImport, onClose]);
+
+  /**
+   * Reset state when dialog closes
+   */
+  useEffect(() => {
+    if (!isOpen) {
+      setSearchQuery('');
+      setDebouncedQuery('');
+      setProjects([]);
+      setSelectedProject(null);
+      setError(null);
+      setPageToken(undefined);
+      setHasMore(false);
+    }
+  }, [isOpen]);
+
+  /**
+   * Format date for display
+   */
+  const formatDate = (dateString?: string) => {
+    if (!dateString) return '-';
+    return new Date(dateString).toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow-xl max-w-3xl w-full mx-4 max-h-[90vh] flex flex-col">
+        {/* Header */}
+        <div className="p-6 border-b border-gray-200">
+          <div className="flex justify-between items-center mb-4">
+            <div className="flex items-center gap-3">
+              <div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
+                <Database className="w-5 h-5 text-blue-600" />
+              </div>
+              <div>
+                <h2 className="text-xl font-bold text-gray-900">
+                  Lark Baseからインポート
+                </h2>
+                <p className="text-sm text-gray-500">
+                  プロジェクト情報を検索してインポート
+                </p>
+              </div>
+            </div>
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600 transition-colors"
+              aria-label="閉じる"
+            >
+              <X className="w-6 h-6" />
+            </button>
+          </div>
+
+          {/* Search Input */}
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="プロジェクト名、コード、場所で検索..."
+              className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-shadow"
+              autoFocus
+            />
+            {searchQuery && (
+              <button
+                onClick={() => setSearchQuery('')}
+                className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-6">
+          {/* Loading State */}
+          {loading && (
+            <div className="flex flex-col items-center justify-center py-12">
+              <Loader2 className="w-8 h-8 text-blue-600 animate-spin mb-3" />
+              <p className="text-gray-500">検索中...</p>
+            </div>
+          )}
+
+          {/* Error State */}
+          {error && !loading && (
+            <div className="flex items-center gap-3 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
+              <AlertCircle className="w-5 h-5 flex-shrink-0" />
+              <p>{error}</p>
+            </div>
+          )}
+
+          {/* Empty State */}
+          {!loading && !error && projects.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-12 text-gray-500">
+              <Database className="w-12 h-12 mb-3 text-gray-300" />
+              <p className="text-lg font-medium">プロジェクトが見つかりません</p>
+              <p className="text-sm mt-1">
+                {searchQuery
+                  ? '別のキーワードで検索してください'
+                  : 'Lark Baseにプロジェクトが登録されていません'}
+              </p>
+            </div>
+          )}
+
+          {/* Project List */}
+          {!loading && projects.length > 0 && (
+            <div className="space-y-3">
+              {projects.map((project) => {
+                const isSelected = selectedProject?.recordId === project.recordId;
+                return (
+                  <button
+                    key={project.recordId}
+                    onClick={() => handleSelect(project)}
+                    className={`w-full text-left p-4 rounded-lg border-2 transition-all ${
+                      isSelected
+                        ? 'border-blue-600 bg-blue-50'
+                        : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <h3 className="font-semibold text-gray-900 truncate">
+                            {project.name}
+                          </h3>
+                          {project.code && (
+                            <span className="text-xs font-mono text-gray-500 bg-gray-100 px-2 py-0.5 rounded">
+                              {project.code}
+                            </span>
+                          )}
+                        </div>
+                        {project.description && (
+                          <p className="text-sm text-gray-600 mt-1 line-clamp-2">
+                            {project.description}
+                          </p>
+                        )}
+                        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 text-xs text-gray-500">
+                          {project.location && (
+                            <span className="flex items-center gap-1">
+                              <MapPin className="w-3 h-3" />
+                              {project.location}
+                            </span>
+                          )}
+                          {(project.startDate || project.endDate) && (
+                            <span className="flex items-center gap-1">
+                              <Calendar className="w-3 h-3" />
+                              {formatDate(project.startDate)} ~{' '}
+                              {formatDate(project.endDate)}
+                            </span>
+                          )}
+                        </div>
+                        {(project.clientName || project.contractorName) && (
+                          <div className="flex flex-wrap gap-x-3 mt-2 text-xs text-gray-500">
+                            {project.clientName && (
+                              <span>発注者: {project.clientName}</span>
+                            )}
+                            {project.contractorName && (
+                              <span>施工者: {project.contractorName}</span>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                      <div
+                        className={`flex-shrink-0 w-6 h-6 rounded-full border-2 flex items-center justify-center ml-3 ${
+                          isSelected
+                            ? 'border-blue-600 bg-blue-600'
+                            : 'border-gray-300'
+                        }`}
+                      >
+                        {isSelected && <Check className="w-4 h-4 text-white" />}
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
+
+              {/* Load More Button */}
+              {hasMore && (
+                <div className="flex justify-center pt-4">
+                  <button
+                    onClick={handleLoadMore}
+                    disabled={loadingMore}
+                    className="flex items-center gap-2 px-4 py-2 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {loadingMore ? (
+                      <>
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                        読み込み中...
+                      </>
+                    ) : (
+                      <>
+                        <ChevronDown className="w-4 h-4" />
+                        もっと読み込む
+                      </>
+                    )}
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="p-6 border-t border-gray-200 bg-gray-50">
+          <div className="flex justify-between items-center">
+            <div className="text-sm text-gray-500">
+              {selectedProject ? (
+                <span className="flex items-center gap-2">
+                  <Check className="w-4 h-4 text-green-600" />
+                  <span className="font-medium text-gray-700">
+                    {selectedProject.name}
+                  </span>
+                  を選択中
+                </span>
+              ) : (
+                'インポートするプロジェクトを選択してください'
+              )}
+            </div>
+            <div className="flex gap-3">
+              <button
+                onClick={onClose}
+                className="px-4 py-2 text-gray-700 hover:bg-gray-200 rounded-lg transition-colors"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={handleImport}
+                disabled={!selectedProject || importing}
+                className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              >
+                {importing ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    インポート中...
+                  </>
+                ) : (
+                  <>
+                    <Database className="w-4 h-4" />
+                    インポート
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default LarkBaseImportDialog;

--- a/src/components/projects/index.ts
+++ b/src/components/projects/index.ts
@@ -7,3 +7,5 @@ export { ProjectCard } from './ProjectCard';
 export { ProjectList } from './ProjectList';
 export { ProjectForm } from './ProjectForm';
 export { DeleteProjectDialog } from './DeleteProjectDialog';
+export { LarkBaseImportDialog } from './LarkBaseImportDialog';
+export type { LarkProjectData } from '@/lib/lark/types';

--- a/src/lib/lark/client.ts
+++ b/src/lib/lark/client.ts
@@ -1,0 +1,224 @@
+/**
+ * Lark Base API Client
+ * Lark Base APIとの通信を担当
+ */
+
+import type {
+  LarkTokenResponse,
+  LarkRecordsResponse,
+  LarkSearchRequest,
+  LarkFilter,
+  LarkRecord,
+  LarkRecordField,
+  LarkProjectMapping,
+  LarkProjectData,
+} from './types';
+
+const LARK_API_BASE = 'https://open.larksuite.com/open-apis';
+
+// トークンキャッシュ
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+/**
+ * Lark Base設定が有効かチェック
+ */
+export function isLarkConfigured(): boolean {
+  return !!(
+    process.env.LARK_APP_ID &&
+    process.env.LARK_APP_SECRET &&
+    process.env.LARK_APP_TOKEN &&
+    process.env.LARK_TABLE_ID
+  );
+}
+
+/**
+ * tenant_access_tokenを取得（キャッシュ付き）
+ */
+export async function getTenantAccessToken(): Promise<string> {
+  // キャッシュが有効な場合はそれを返す
+  if (cachedToken && Date.now() < cachedToken.expiresAt - 60000) {
+    return cachedToken.token;
+  }
+
+  const response = await fetch(
+    `${LARK_API_BASE}/auth/v3/tenant_access_token/internal`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        app_id: process.env.LARK_APP_ID,
+        app_secret: process.env.LARK_APP_SECRET,
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Lark auth failed: ${response.status}`);
+  }
+
+  const data: LarkTokenResponse = await response.json();
+
+  if (data.code !== 0) {
+    throw new Error(`Lark auth error: ${data.msg}`);
+  }
+
+  // キャッシュを更新
+  cachedToken = {
+    token: data.tenant_access_token,
+    expiresAt: Date.now() + data.expire * 1000,
+  };
+
+  return data.tenant_access_token;
+}
+
+/**
+ * Lark Baseテーブルからレコードを検索
+ */
+export async function searchRecords(
+  request: LarkSearchRequest = {}
+): Promise<LarkRecordsResponse> {
+  const token = await getTenantAccessToken();
+  const appToken = process.env.LARK_APP_TOKEN;
+  const tableId = process.env.LARK_TABLE_ID;
+
+  const response = await fetch(
+    `${LARK_API_BASE}/bitable/v1/apps/${appToken}/tables/${tableId}/records/search`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        page_size: request.page_size || 20,
+        page_token: request.page_token,
+        filter: request.filter,
+        sort: request.sort,
+        field_names: request.field_names,
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Lark API failed: ${response.status}`);
+  }
+
+  const data: LarkRecordsResponse = await response.json();
+
+  if (data.code !== 0) {
+    throw new Error(`Lark API error: ${data.msg}`);
+  }
+
+  return data;
+}
+
+/**
+ * テキスト検索用のフィルター条件を構築
+ */
+export function buildSearchFilter(
+  searchText: string,
+  searchFields: string[]
+): LarkFilter {
+  return {
+    conjunction: 'or',
+    conditions: searchFields.map((field) => ({
+      field_name: field,
+      operator: 'contains' as const,
+      value: [searchText],
+    })),
+  };
+}
+
+/**
+ * フィールド値を抽出するヘルパー
+ */
+function extractFieldValue(
+  field: LarkRecordField | undefined
+): string | null {
+  if (!field) return null;
+
+  // テキスト型
+  if (field.text !== undefined) {
+    if (typeof field.text === 'string') {
+      return field.text;
+    }
+    if (Array.isArray(field.text)) {
+      return field.text.map((t) => t.text).join('');
+    }
+  }
+
+  // 数値型
+  if (field.number !== undefined) {
+    return String(field.number);
+  }
+
+  // 日付型（Unix timestamp to ISO string）
+  if (field.date !== undefined) {
+    return new Date(field.date).toISOString().split('T')[0];
+  }
+
+  // 選択型
+  if (field.select !== undefined) {
+    return field.select;
+  }
+
+  return null;
+}
+
+/**
+ * デフォルトのフィールドマッピング
+ */
+export function getDefaultMapping(): LarkProjectMapping {
+  return {
+    nameField: process.env.LARK_FIELD_NAME || '案件名',
+    codeField: process.env.LARK_FIELD_CODE || '案件コード',
+    clientNameField: process.env.LARK_FIELD_CLIENT || '発注者',
+    contractorNameField: process.env.LARK_FIELD_CONTRACTOR || '施工者',
+    locationField: process.env.LARK_FIELD_LOCATION || '工事場所',
+    startDateField: process.env.LARK_FIELD_START_DATE || '着工日',
+    endDateField: process.env.LARK_FIELD_END_DATE || '完工日',
+    descriptionField: process.env.LARK_FIELD_DESCRIPTION || '備考',
+  };
+}
+
+/**
+ * Lark BaseレコードをProjectデータに変換
+ */
+export function mapRecordToProject(
+  record: LarkRecord,
+  mapping: LarkProjectMapping = getDefaultMapping()
+): LarkProjectData {
+  const fields = record.fields;
+
+  const name = extractFieldValue(fields[mapping.nameField] as LarkRecordField);
+
+  if (!name) {
+    throw new Error(`Record ${record.record_id} has no name field`);
+  }
+
+  return {
+    recordId: record.record_id,
+    name,
+    code: mapping.codeField
+      ? extractFieldValue(fields[mapping.codeField] as LarkRecordField) || undefined
+      : undefined,
+    clientName: mapping.clientNameField
+      ? extractFieldValue(fields[mapping.clientNameField] as LarkRecordField) || undefined
+      : undefined,
+    contractorName: mapping.contractorNameField
+      ? extractFieldValue(fields[mapping.contractorNameField] as LarkRecordField) || undefined
+      : undefined,
+    location: mapping.locationField
+      ? extractFieldValue(fields[mapping.locationField] as LarkRecordField) || undefined
+      : undefined,
+    startDate: mapping.startDateField
+      ? extractFieldValue(fields[mapping.startDateField] as LarkRecordField) || undefined
+      : undefined,
+    endDate: mapping.endDateField
+      ? extractFieldValue(fields[mapping.endDateField] as LarkRecordField) || undefined
+      : undefined,
+    description: mapping.descriptionField
+      ? extractFieldValue(fields[mapping.descriptionField] as LarkRecordField) || undefined
+      : undefined,
+  };
+}

--- a/src/lib/lark/types.ts
+++ b/src/lib/lark/types.ts
@@ -1,0 +1,108 @@
+/**
+ * Lark Base API Types
+ * Lark Base連携のための型定義
+ */
+
+// Lark API認証設定
+export interface LarkAuthConfig {
+  appId: string;
+  appSecret: string;
+  appToken: string;
+  tableId: string;
+}
+
+// Lark トークンレスポンス
+export interface LarkTokenResponse {
+  code: number;
+  msg: string;
+  tenant_access_token: string;
+  expire: number;
+}
+
+// Lark Base レコードフィールド
+export interface LarkRecordField {
+  text?: string | { text: string }[];
+  number?: number;
+  date?: number;
+  select?: string;
+  multi_select?: string[];
+  [key: string]: unknown;
+}
+
+// Lark Base レコード
+export interface LarkRecord {
+  record_id: string;
+  fields: Record<string, LarkRecordField>;
+}
+
+// Lark Base レコードレスポンス
+export interface LarkRecordsResponse {
+  code: number;
+  msg: string;
+  data: {
+    has_more: boolean;
+    page_token?: string;
+    total: number;
+    items: LarkRecord[];
+  };
+}
+
+// 検索リクエスト
+export interface LarkSearchRequest {
+  page_size?: number;
+  page_token?: string;
+  filter?: LarkFilter;
+  sort?: LarkSort[];
+  field_names?: string[];
+}
+
+// フィルター条件
+export interface LarkFilter {
+  conjunction: 'and' | 'or';
+  conditions: LarkCondition[];
+}
+
+// 検索条件
+export interface LarkCondition {
+  field_name: string;
+  operator: 'is' | 'isNot' | 'contains' | 'doesNotContain' | 'isEmpty' | 'isNotEmpty' | 'isGreater' | 'isLess';
+  value?: string[];
+}
+
+// ソート条件
+export interface LarkSort {
+  field_name: string;
+  desc?: boolean;
+}
+
+// プロジェクトフィールドマッピング
+export interface LarkProjectMapping {
+  nameField: string;
+  codeField?: string;
+  clientNameField?: string;
+  contractorNameField?: string;
+  locationField?: string;
+  startDateField?: string;
+  endDateField?: string;
+  descriptionField?: string;
+}
+
+// PhotoManagement用プロジェクトデータ
+export interface LarkProjectData {
+  recordId: string;
+  name: string;
+  code?: string;
+  clientName?: string;
+  contractorName?: string;
+  location?: string;
+  startDate?: string;
+  endDate?: string;
+  description?: string;
+}
+
+// APIレスポンス
+export interface LarkApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}


### PR DESCRIPTION
## Summary
- Lark Baseの案件一覧から案件を検索してプロジェクトとしてインポートできる機能を追加
- プロジェクト作成画面に「Lark Baseからインポート」ボタンを追加
- 検索結果から案件を選択すると、フォームに自動入力される

## 変更内容
### 新規ファイル
- `src/lib/lark/types.ts` - Lark Base API型定義
- `src/lib/lark/client.ts` - Lark Base APIクライアント
- `src/app/api/lark/config/route.ts` - 設定チェックAPI
- `src/app/api/lark/records/route.ts` - レコード検索API
- `src/components/projects/LarkBaseImportDialog.tsx` - インポートダイアログ

### 修正ファイル
- `src/components/projects/ProjectForm.tsx` - インポートボタン統合
- `src/components/projects/index.ts` - エクスポート追加

## 環境変数（.env設定が必要）
```
LARK_APP_ID=your_app_id
LARK_APP_SECRET=your_app_secret
LARK_APP_TOKEN=your_base_app_token
LARK_TABLE_ID=your_table_id
```

## Test plan
- [ ] Lark Base認証情報なしでインポートボタンが表示されないこと
- [ ] Lark Base認証情報ありでインポートボタンが表示されること
- [ ] 案件検索が正常に動作すること
- [ ] 案件選択→インポートでフォームに値が入力されること
- [ ] ビルドが成功すること ✅

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)