### PR TITLE
feat: プロジェクト詳細ページを日本語化

### DIFF
--- a/src/app/(dashboard)/projects/[id]/page.tsx
+++ b/src/app/(dashboard)/projects/[id]/page.tsx
@@ -77,8 +77,8 @@ export default async function ProjectDetailPage({ params }: ProjectDetailPagePro
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
         </svg>
       ),
-      label: 'Photos',
-      description: 'View and manage project photos',
+      label: '写真',
+      description: '写真の閲覧・管理',
       count: project._count.photos,
     },
     {
@@ -88,8 +88,8 @@ export default async function ProjectDetailPage({ params }: ProjectDetailPagePro
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
         </svg>
       ),
-      label: 'Albums',
-      description: 'Organize photos into albums',
+      label: 'アルバム',
+      description: '写真をアルバムに整理',
       count: project._count.albums,
     },
     {
@@ -99,8 +99,8 @@ export default async function ProjectDetailPage({ params }: ProjectDetailPagePro
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
         </svg>
       ),
-      label: 'Categories',
-      description: 'Manage photo categories',
+      label: 'カテゴリー',
+      description: 'カテゴリーの管理',
       count: project._count.categories,
     },
     {
@@ -110,8 +110,8 @@ export default async function ProjectDetailPage({ params }: ProjectDetailPagePro
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
         </svg>
       ),
-      label: 'Blackboard',
-      description: 'Create construction blackboards',
+      label: '黒板',
+      description: '工事用黒板の作成',
       count: null,
     },
     {
@@ -122,8 +122,8 @@ export default async function ProjectDetailPage({ params }: ProjectDetailPagePro
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
         </svg>
       ),
-      label: 'Settings',
-      description: 'Project settings and members',
+      label: '設定',
+      description: 'プロジェクト設定・メンバー',
       count: null,
     },
   ];
@@ -176,7 +176,7 @@ export default async function ProjectDetailPage({ params }: ProjectDetailPagePro
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
               </svg>
-              Settings
+              設定
             </Link>
           </div>
         </div>
@@ -224,23 +224,23 @@ export default async function ProjectDetailPage({ params }: ProjectDetailPagePro
 
           {/* Stats Card */}
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">Statistics</h2>
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">統計情報</h2>
             <div className="grid grid-cols-2 gap-4">
               <div className="text-center p-3 bg-blue-50 rounded-lg">
                 <div className="text-2xl font-bold text-blue-600">{project._count.photos}</div>
-                <div className="text-xs text-blue-600">Photos</div>
+                <div className="text-xs text-blue-600">写真</div>
               </div>
               <div className="text-center p-3 bg-purple-50 rounded-lg">
                 <div className="text-2xl font-bold text-purple-600">{project._count.albums}</div>
-                <div className="text-xs text-purple-600">Albums</div>
+                <div className="text-xs text-purple-600">アルバム</div>
               </div>
               <div className="text-center p-3 bg-green-50 rounded-lg">
                 <div className="text-2xl font-bold text-green-600">{project._count.categories}</div>
-                <div className="text-xs text-green-600">Categories</div>
+                <div className="text-xs text-green-600">カテゴリー</div>
               </div>
               <div className="text-center p-3 bg-orange-50 rounded-lg">
                 <div className="text-2xl font-bold text-orange-600">{project._count.members}</div>
-                <div className="text-xs text-orange-600">Members</div>
+                <div className="text-xs text-orange-600">メンバー</div>
               </div>
             </div>
           </div>
@@ -248,12 +248,12 @@ export default async function ProjectDetailPage({ params }: ProjectDetailPagePro
           {/* Team Card */}
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-gray-900">Team</h2>
+              <h2 className="text-lg font-semibold text-gray-900">チーム</h2>
               <Link
                 href={`/projects/${id}/settings`}
                 className="text-sm text-blue-600 hover:text-blue-500"
               >
-                Manage
+                管理
               </Link>
             </div>
             {project.members.length > 0 ? (
@@ -283,18 +283,18 @@ export default async function ProjectDetailPage({ params }: ProjectDetailPagePro
                 ))}
                 {project._count.members > 5 && (
                   <p className="text-sm text-gray-500">
-                    +{project._count.members - 5} more members
+                    他 {project._count.members - 5} 人
                   </p>
                 )}
               </div>
             ) : (
-              <p className="text-sm text-gray-500">No team members yet</p>
+              <p className="text-sm text-gray-500">チームメンバーはまだいません</p>
             )}
           </div>
         </div>
 
         {/* Quick Navigation */}
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Quick Access</h2>
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">クイックアクセス</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4 mb-8">
           {navigationItems.map((item) => (
             <Link
@@ -310,7 +310,7 @@ export default async function ProjectDetailPage({ params }: ProjectDetailPagePro
               </div>
               <p className="text-sm text-gray-500">{item.description}</p>
               {item.count !== null && (
-                <p className="text-sm font-medium text-blue-600 mt-2">{item.count} items</p>
+                <p className="text-sm font-medium text-blue-600 mt-2">{item.count} 件</p>
               )}
             </Link>
           ))}
@@ -320,12 +320,12 @@ export default async function ProjectDetailPage({ params }: ProjectDetailPagePro
         {project.albums.length > 0 && (
           <div>
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-gray-900">Recent Albums</h2>
+              <h2 className="text-lg font-semibold text-gray-900">最近のアルバム</h2>
               <Link
                 href={`/projects/${id}/albums`}
                 className="text-sm text-blue-600 hover:text-blue-500"
               >
-                View all
+                すべて表示
               </Link>
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -337,7 +337,7 @@ export default async function ProjectDetailPage({ params }: ProjectDetailPagePro
                 >
                   <h3 className="font-medium text-gray-900 truncate mb-2">{album.name}</h3>
                   <p className="text-sm text-gray-500">
-                    {album._count.photos} photos
+                    {album._count.photos} 枚
                   </p>
                 </Link>
               ))}


### PR DESCRIPTION
## Summary
- プロジェクト詳細ページのすべての英語テキストを日本語に翻訳

## 変更内容

| 変更前 | 変更後 |
|--------|--------|
| Photos | 写真 |
| Albums | アルバム |
| Categories | カテゴリー |
| Blackboard | 黒板 |
| Settings | 設定 |
| Statistics | 統計情報 |
| Team | チーム |
| Manage | 管理 |
| Quick Access | クイックアクセス |
| Recent Albums | 最近のアルバム |
| View all | すべて表示 |
| X items | X 件 |
| X photos | X 枚 |
| +X more members | 他 X 人 |
| No team members yet | チームメンバーはまだいません |

## Test plan
- [ ] プロジェクト詳細ページを開く
- [ ] すべてのテキストが日本語で表示される
- [ ] クイックアクセスのリンクが正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)